### PR TITLE
Ninja file generation, without base and base-devel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.pyc
-deps_graph/.container_build
+logs
+__pycache__
+build.ninja
+.ninja_deps
+.ninja_log
+*.ninja_syntax.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,66 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Top-level tuscan Makefile.
+
+TIMESTAMP=$(shell date +%Y%m%dT%H%M%S)
+
+define make_log_dir
+@mkdir -p logs/$1/$(TIMESTAMP)
+@-rm logs/$1/latest
+@ln -sf $(shell pwd)/logs/$1/$(TIMESTAMP) logs/$1/latest
+endef
+
+BUILD_FILE = $(shell pwd)/logs/deps_to_ninja/latest/build.ninja
+ECHO = >&2 echo
+
+# Top-level targets
+# `````````````````
+# each target corresponds to a top-level directory in this repository.
+
+default: deps_to_ninja
+
+deps_to_ninja: $(BUILD_FILE)
+
+
+# Directory 'deps_to_ninja'
+# ``````````````````````
+
+$(BUILD_FILE): .container_build_deps_to_ninja
+	@$(call make_log_dir,deps_to_ninja)
+	@$(ECHO) Calculating dependencies
+	@docker run                                    \
+	  -v $(shell pwd)/logs/deps_to_ninja/$(TIMESTAMP):/build/logs \
+	  deps_to_ninja_container
+	@-ln -s $@ build.ninja
+
+.container_build_deps_to_ninja: \
+	deps_to_ninja/Dockerfile deps_to_ninja/deps_to_ninja.py
+	@$(ECHO) Building dependencies container
+	@cp ninja_syntax.py deps_to_ninja/.ninja_syntax.py
+	@docker build -q -t deps_to_ninja_container deps_to_ninja >/dev/null
+	@touch $@
+
+
+# docker is a disk space hog.
+.PHONY: docker_stop docker_cleanup
+docker_stop:
+	@-docker stop $$(docker ps -a -q)
+	@-docker rm $$(docker ps -a -q)
+	@rm .container_build_deps_to_ninja
+
+# Also delete images
+docker_cleanup: docker_stop
+	@-docker rmi -f $$(docker images -q)

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ convenience.
 Directories
 -----------
 
-*   deps_graph:
+*   deps_to_ninja
 
     A python script and associated container that outputs dependency
-    relationships between all Arch Linux packages. This only needs to be
-    run once, although it's fairly speedy.
+    relationships between all Arch Linux packages as a ninja build file.
 
 
 
@@ -35,3 +34,7 @@ Dependencies
 *   docker
 
     (you should add your user to the 'docker' group)
+
+*   ninja
+
+    http://martine.github.io/ninja/

--- a/deps_to_ninja/Dockerfile
+++ b/deps_to_ninja/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Arch Linux container for building all dependencies of all Arch Linux
+# packages.
+#
+# USAGE:
+#   docker run container_name
+
+FROM base/arch:latest
+MAINTAINER Kareem Khazem <khazem@google.com>
+
+RUN pacman-key --refresh-keys     && \
+    pacman -Syu --noconfirm base-devel
+
+RUN pacman-db-upgrade && \
+    pacman -S --noconfirm abs python
+
+# Sync Arch Build System repository
+RUN abs
+
+COPY deps_to_ninja.py /build/deps_to_ninja.py
+COPY .ninja_syntax.py /build/ninja_syntax.py
+
+ENTRYPOINT ["/usr/bin/python", "-u", "/build/deps_to_ninja.py"]

--- a/deps_to_ninja/deps_to_ninja.py
+++ b/deps_to_ninja/deps_to_ninja.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Building Arch Linux from source as a ninja build file.
+
+When run in an Arch Linux container, this script generates a ninja [1]
+build file. Running that build file shall cause every official Arch
+Linux package to be built from source in reverse-dependency order.
+
+In Arch Linux, building from source is done using the Arch Build System
+(ABS). This is a set of directories located under /var/abs; each such
+directory contains exactly one Bash script called PKGBUILD. Each
+PKGBUILD may build one or more packages. PKGBUILDs may specify zero or
+more 'makedepends', which are those packages that must be installed
+before attempting to build the packages of that PKGBUILD. In order to
+build the packages specified by the PKGBUILD, one must cd into the
+PKGBUILD's directory and run 'makepkg'.
+
+This is summarized in this diagram, taken from the perspective of a
+single PKGBUILD. Note that various PKGBUILDs in Arch might overlap in
+the packages that they makedepend on, so building a single package might
+satisfy several PKGBUILDs and allow those PKGBUILD's packages to be
+built.
+
+    packages  <------------
+       ^                  |
+       | 1-*              |
+       |                  |
+       | builds           |
+       |                  |
+       |               makedepends
+    PKGBUILD            are just
+       |              other packages
+       |                  |
+       | depends on       |
+       |                  |
+       | *                |
+       v                  |
+    makedepends  --------/
+
+Thus, suppose that we have a PKGBUILD for the directory 'core/foo',
+which builds the packages 'p1' and 'p2', and which makedepends on the
+packages 'd1' and 'd2'. Conceptually, the ninja build commands that this
+script shall generate are:
+________________________________________________________________________
+rule makepkg
+    command = cd /var/abs/${in} && /usr/bin/makepkg
+
+rule emptyrule
+    command = /usr/bin/true
+
+build p1.pkg.tar.xz: makepkg core/foo
+build p2.pkg.tar.xz: makepkg core/foo
+
+build core/foo: emptyrule  d1.pkg.tar.xz  d2.pkg.tar.xz
+________________________________________________________________________
+...plus the build commands for d{1,2}.pkg.tar.xz, etc. Note that the
+actual output will be slightly different, in order to ensure that
+packages are not rebuilt unnecessarily.
+
+[1] http://martine.github.io/ninja/
+"""
+
+from glob import glob
+from multiprocessing import Value, Lock, Pool, cpu_count
+from ninja_syntax import Writer
+from re import sub
+from subprocess import PIPE, Popen, TimeoutExpired
+from sys import stderr, stdout
+from tempfile import NamedTemporaryFile as tempfile
+from textwrap import dedent
+
+
+def excluded(pkgbuild):
+    """Shall we not bother to make packages described by pkgbuild?"""
+    return pkgbuild in [
+        # Libreoffice internationalisation packs call curl from their
+        # buildfile, and they are not required by anything. Skip them
+        # for all operations
+        "/var/abs/extra/libreoffice-fresh-i18n/PKGBUILD",
+        "/var/abs/extra/libreoffice-still-i18n/PKGBUILD",
+    ]
+
+
+def pkgnames_of(pkgbuild):
+    """The pkgnames defined by a PKGBUILD file
+
+    A single PKGBUILD may build one or more binary packages when makepkg
+    is invoked. This function returns the names of the packages that the
+    specified PKGBUILD builds.
+
+    Arguments:
+        pkgbuild: an absolute path to a PKGBUILD
+
+    Returns:
+        a list of names of packages, or None if we should not build
+        packages from this PKGBUILD
+    """
+
+    if excluded(pkgbuild): return None
+
+    cmd = dedent("""\
+                 #!/bin/bash
+                 . %s
+                 for pack in ${pkgname[@]}; do
+                    echo ${pack};
+                 done;
+                 """ % (pkgbuild))
+    with tempfile(mode="w") as temp:
+        temp.write(cmd)
+        temp.flush()
+        proc = Popen(["/bin/bash", temp.name], stdout=PIPE)
+        try:
+            proc.wait(5)
+        except TimeoutExpired:
+            print(pkgbuild + " took too long to source",
+                  file=stderr)
+            exit(1)
+        names = [p.decode().strip() for p in list(proc.stdout)
+                 if p.decode().strip()]
+        if len(names) == 0:
+            print(pkgbuild + " has no pkgname",
+                  file=stderr)
+            exit(1)
+        return names
+
+
+def makedepends_of(pkgbuild):
+    """The makedepends defined by a PKGBUILD file
+
+    A single PKGBUILD may contain a makedepends array, which indicates
+    what packages must be installed in order to build the PKGBUILD. Note
+    that even if a PKGBUILD builds multiple packages, the globally-
+    defined makedepends array applies to ALL those packages (see [1] or
+    search the PKGBUILD manpage for 'Package Splitting').
+
+    Note that all packages are assumed to require all packages from the
+    base-devel group [2] in order to be built using makepkg, as noted in
+    this wiki page [3]. Therefore this function shall contain at least
+    those packages. Furthermore, all Arch Linux systems are expected to
+    contain all packages from the base group, so those packages shall
+    also be returned.
+
+    [1]: archlinux.org/pacman/PKGBUILD.5.html#_package_splitting
+    [2]: archlinux.org/groups/x86_64/base-devel/
+    [3]: wiki.archlinux.org/index.php/PKGBUILD#makedepends
+
+    Arguments:
+        pkgbuild: an absolute path to a PKGBUILD
+
+    Returns:
+        a list of packages that must be installed in order to build that
+        PKGBUILD, including (at least) all packages in the base and
+        base-devel groups. Or, None if we should not create any packages
+        from this PKGBUILD.
+    """
+
+    if excluded(pkgbuild): return None
+
+    cmd = dedent("""\
+                 #!/bin/bash
+                 . %s
+                 for dep in ${makedepends[@]}; do
+                    echo ${dep};
+                 done;
+                 """ % (pkgbuild))
+    with tempfile(mode="w") as temp:
+        temp.write(cmd)
+        temp.flush()
+        proc = Popen(["/bin/bash", temp.name], stdout=PIPE)
+        try:
+            proc.wait(5)
+        except TimeoutExpired:
+            print(pkgbuild + " took too long to source",
+                  file=stderr)
+            exit(1)
+        depends = ["binaries/" + p.decode().strip() + ".pkg.tar.xz"
+                   for p in list(proc.stdout) if p.decode().strip()]
+        return depends
+
+
+def ninja_builds_for(abs_dir):
+    pkgbuild = abs_dir + "/PKGBUILD"
+    target_packages = pkgnames_of(pkgbuild)
+    if not target_packages: return
+
+    target_packages = ["binaries/" + n + ".pkg.tar.xz"
+                       for n in target_packages]
+
+    depends = makedepends_of(pkgbuild)
+
+    build_name = sub("/var/abs/\w+/", "", abs_dir)
+    build_name = sub("/", "@", build_name)
+
+    if build_name in depends: depends.remove(build_name)
+
+    with lock:
+        ninja.build(target_packages, "makepkg", build_name)
+        ninja.build(build_name, "empty", depends)
+        ninja.output.flush()
+
+        number_of_packages.value += len(target_packages)
+        counter.value += 1
+        print("\r" + str(counter.value) + "/" + builds_len +
+              ", " + str(number_of_packages.value) +
+              " packages found.", file=stderr, end="")
+
+
+def main():
+    """This script should be run inside a container."""
+    global builds_len, ninja
+
+    with open("/build/logs/build.ninja", "w") as log:
+        ninja = Writer(log, 72)
+
+        ninja.rule("makepkg", "cd /var/abs/${in} && makepkg")
+        ninja.rule("empty", "/usr/bin/true")
+
+        log.flush()
+
+        builds = glob("/var/abs/*/*")
+        builds = [b for b in builds if not excluded(b)]
+        builds_len = str(len(builds))
+        with Pool(cpu_count()) as p:
+            p.map(ninja_builds_for, builds)
+
+        print("", file=stderr)
+
+
+# Globals, referenced from spawned processes. Remember to initialize
+# these things in main!
+counter = Value("i", 0)
+number_of_packages = Value("i", 0)
+lock = Lock()
+builds_len = ""
+ninja = None
+
+
+# Arch Linux packages in the 'base' group, i.e. expected to be installed
+# on all Arch Linux systems
+base_packages = [
+    "bash", "bzip2", "coreutils", "cryptsetup", "device-mapper",
+    "dhcpcd", "diffutils", "e2fsprogs", "file", "filesystem",
+    "findutils", "gawk", "gcc-libs", "gettext", "glibc", "grep", "gzip",
+    "inetutils", "iproute2", "iputils", "jfsutils", "less", "licenses",
+    "linux", "logrotate", "lvm2", "man-db", "man-pages", "mdadm",
+    "nano", "netctl", "pacman", "pciutils", "pcmciautils", "perl",
+    "procps-ng", "psmisc", "reiserfsprogs", "s-nail", "sed", "shadow",
+    "sysfsutils", "systemd-sysvcompat", "tar", "texinfo", "usbutils",
+    "util-linux", "vi", "which", "xfsprogs"
+]
+
+# Arch Linux packages in the 'base-devel' group, expected to be
+# installed if one wishes to build packages from source using makepkg
+base_devel_packages = [
+    "autoconf", "automake", "binutils", "bison", "fakeroot", "file",
+    "findutils", "flex", "gawk", "gcc", "gettext", "grep", "groff",
+    "gzip", "libtool", "m4", "make", "pacman", "patch", "pkg-config",
+    "sed", "sudo", "texinfo", "util-linux", "which"
+]
+
+
+if __name__ == "__main__":
+    main()

--- a/ninja_syntax.py
+++ b/ninja_syntax.py
@@ -1,0 +1,175 @@
+#!/usr/bin/python
+
+"""Python module for generating .ninja files.
+
+Note that this is emphatically not a required piece of Ninja; it's
+just a helpful utility for build-file-generation systems that already
+use Python.
+"""
+
+import re
+import textwrap
+
+def escape_path(word):
+    return word.replace('$ ', '$$ ').replace(' ', '$ ').replace(':', '$:')
+
+class Writer(object):
+    def __init__(self, output, width=78):
+        self.output = output
+        self.width = width
+
+    def newline(self):
+        self.output.write('\n')
+
+    def comment(self, text):
+        for line in textwrap.wrap(text, self.width - 2):
+            self.output.write('# ' + line + '\n')
+
+    def variable(self, key, value, indent=0):
+        if value is None:
+            return
+        if isinstance(value, list):
+            value = ' '.join(filter(None, value))  # Filter out empty strings.
+        self._line('%s = %s' % (key, value), indent)
+
+    def pool(self, name, depth):
+        self._line('pool %s' % name)
+        self.variable('depth', depth, indent=1)
+
+    def rule(self, name, command, description=None, depfile=None,
+             generator=False, pool=None, restat=False, rspfile=None,
+             rspfile_content=None, deps=None):
+        self._line('rule %s' % name)
+        self.variable('command', command, indent=1)
+        if description:
+            self.variable('description', description, indent=1)
+        if depfile:
+            self.variable('depfile', depfile, indent=1)
+        if generator:
+            self.variable('generator', '1', indent=1)
+        if pool:
+            self.variable('pool', pool, indent=1)
+        if restat:
+            self.variable('restat', '1', indent=1)
+        if rspfile:
+            self.variable('rspfile', rspfile, indent=1)
+        if rspfile_content:
+            self.variable('rspfile_content', rspfile_content, indent=1)
+        if deps:
+            self.variable('deps', deps, indent=1)
+
+    def build(self, outputs, rule, inputs=None, implicit=None, order_only=None,
+              variables=None):
+        outputs = as_list(outputs)
+        out_outputs = [escape_path(x) for x in outputs]
+        all_inputs = [escape_path(x) for x in as_list(inputs)]
+
+        if implicit:
+            implicit = [escape_path(x) for x in as_list(implicit)]
+            all_inputs.append('|')
+            all_inputs.extend(implicit)
+        if order_only:
+            order_only = [escape_path(x) for x in as_list(order_only)]
+            all_inputs.append('||')
+            all_inputs.extend(order_only)
+
+        self._line('build %s: %s' % (' '.join(out_outputs),
+                                     ' '.join([rule] + all_inputs)))
+
+        if variables:
+            if isinstance(variables, dict):
+                iterator = iter(variables.items())
+            else:
+                iterator = iter(variables)
+
+            for key, val in iterator:
+                self.variable(key, val, indent=1)
+
+        return outputs
+
+    def include(self, path):
+        self._line('include %s' % path)
+
+    def subninja(self, path):
+        self._line('subninja %s' % path)
+
+    def default(self, paths):
+        self._line('default %s' % ' '.join(as_list(paths)))
+
+    def _count_dollars_before_index(self, s, i):
+        """Returns the number of '$' characters right in front of s[i]."""
+        dollar_count = 0
+        dollar_index = i - 1
+        while dollar_index > 0 and s[dollar_index] == '$':
+            dollar_count += 1
+            dollar_index -= 1
+        return dollar_count
+
+    def _line(self, text, indent=0):
+        """Write 'text' word-wrapped at self.width characters."""
+        leading_space = '  ' * indent
+        while len(leading_space) + len(text) > self.width:
+            # The text is too wide; wrap if possible.
+
+            # Find the rightmost space that would obey our width constraint and
+            # that's not an escaped space.
+            available_space = self.width - len(leading_space) - len(' $')
+            space = available_space
+            while True:
+                space = text.rfind(' ', 0, space)
+                if (space < 0 or
+                    self._count_dollars_before_index(text, space) % 2 == 0):
+                    break
+
+            if space < 0:
+                # No such space; just use the first unescaped space we can find.
+                space = available_space - 1
+                while True:
+                    space = text.find(' ', space + 1)
+                    if (space < 0 or
+                        self._count_dollars_before_index(text, space) % 2 == 0):
+                        break
+            if space < 0:
+                # Give up on breaking.
+                break
+
+            self.output.write(leading_space + text[0:space] + ' $\n')
+            text = text[space+1:]
+
+            # Subsequent lines are continuations, so indent them.
+            leading_space = '  ' * (indent+2)
+
+        self.output.write(leading_space + text + '\n')
+
+    def close(self):
+        self.output.close()
+
+
+def as_list(input):
+    if input is None:
+        return []
+    if isinstance(input, list):
+        return input
+    return [input]
+
+
+def escape(string):
+    """Escape a string such that it can be embedded into a Ninja file without
+    further interpretation."""
+    assert '\n' not in string, 'Ninja syntax does not allow newlines'
+    # We only have one special metacharacter: '$'.
+    return string.replace('$', '$$')
+
+
+def expand(string, vars, local_vars={}):
+    """Expand a string containing $vars as Ninja would.
+
+    Note: doesn't handle the full Ninja variable syntax, but it's enough
+    to make configure.py's use of it work.
+    """
+    def exp(m):
+        var = m.group(1)
+        if var == '$':
+            return '$'
+        return local_vars.get(var, vars.get(var, ''))
+    return re.sub(r'\$(\$|\w*)', exp, string)


### PR DESCRIPTION
Testing this commit:
  running 'make' should be sufficient. The output should be a ninja file
  stored in logs/deps_to_ninja/latest/build.ninja.

Commit details:
  We now generate a ninja build file to build Arch linux from source.
  The ninja file currently doesn't get the dependencies correct for
  packages in the base and base-devel group, as there is a lot of
  bootstrapping involved here. As a result, you can do

```
make
ninja chromium
```

  but the second command won't work due to dependency cycles.
