### PR TITLE
Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+language: python
+
+python:
+  - "3.5"
+
+script: VERBOSE="yes" make -j test
+
+services:
+  - docker

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ BUILD_MARKER_DTN = .$(DIR_DTN)_container_marker
 
 default: deps_to_ninja
 
+test: deps_to_ninja
+
 deps_to_ninja: $(BUILD_FILE)
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Project Tuscan
 ==============
 
+[![Build Status](https://travis-ci.org/karkhaz/tuscan.svg)](https://travis-ci.org/karkhaz/tuscan)
+
 Experiments for evaluating the compilability of a large corpus of
 programs in various compilation environments:
 


### PR DESCRIPTION
this commit adds support for testing with travis. Currently, there are
no tests, but this commit makes travis run the default make target.
