### PR TITLE
deps_to_ninja prints dependency stats when verbose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
-logs
+output
 __pycache__
 build.ninja
 .ninja_deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 python:
   - "3.5"
 
-script: VERBOSE="yes" make -j test
+script: STATISTICS="yes" make -j test
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,12 @@ VERBOSE := >/dev/null
 VERBOSE_SWITCH := 
 else
 VERBOSE := 
-VERBOSE_SWITCH := "-v"
+VERBOSE_SWITCH := "--verbose"
 endif
 
+SWITCHES = $(VERBOSE_SWITCH)
+
+IGNORE_ERROR = 2>/dev/null || true
 IGNORE_ERROR = 2>/dev/null || true
 
 MY_UID = $(shell id -u)
@@ -90,7 +93,6 @@ deps_to_ninja: $(BUILD_FILE)
 		    s/__GROUP_NAME/$(MY_GROUP)/g;     \
 				s/__UID/$(MY_UID)/g;              \
 				s/__GID/$(MY_GID)/g;              \
-				s/__VERBOSE/$(VERBOSE_SWITCH)/g;  \
 				 /#.*/d;" < $<  >> $@
 
 
@@ -101,7 +103,7 @@ $(BUILD_FILE): $(BUILD_MARKER_DTN) $(MARKER_GFP)
 	@$(ECHO) Calculating dependencies
 	@$(call make_output_dir,$(DIR_DTN))
 	@docker run -v $(call output_dir,$(DIR_DTN)):/build/logs \
-		$(CONTAINER_DTN) $(VERBOSE)
+		$(CONTAINER_DTN) $(SWITCHES) $(VERBOSE)
 	@-ln -s $@ build.ninja $(IGNORE_ERROR)
 
 $(BUILD_MARKER_DTN): $(DOCKERFILE_DTN) $(SCRIPT_DTN) $(PULL_ARCH_MARKER)
@@ -118,7 +120,7 @@ $(BUILD_MARKER_DTN): $(DOCKERFILE_DTN) $(SCRIPT_DTN) $(PULL_ARCH_MARKER)
 $(MARKER_GFP): $(BUILD_MARKER_GFP)
 	@$(ECHO) Getting fundamental packages
 	@docker run -v $(call output_dir,$(DIR_GFP)):/build/packages \
-		$(CONTAINER_GFP) $(VERBOSE)
+		$(CONTAINER_GFP) $(SWITCHES) $(VERBOSE)
 	@touch $@
 
 $(BUILD_MARKER_GFP): $(DOCKERFILE_GFP) $(SCRIPT_GFP) $(PULL_ARCH_MARKER)

--- a/deps_to_ninja/deps_to_ninja.py
+++ b/deps_to_ninja/deps_to_ninja.py
@@ -75,12 +75,14 @@ packages are not rebuilt unnecessarily.
 [1] http://martine.github.io/ninja/
 """
 
+from argparse import ArgumentParser
 from glob import glob
-from multiprocessing import Value, Lock, Pool, cpu_count
+from multiprocessing import Value, Lock, Pool, cpu_count, Manager
 from ninja_syntax import Writer
+from os import linesep
 from re import sub
-from subprocess import PIPE, Popen, TimeoutExpired
-from sys import stderr, stdout
+from subprocess import PIPE, Popen, TimeoutExpired, run
+from sys import stderr, stdout, argv
 from tempfile import NamedTemporaryFile as tempfile
 from textwrap import dedent
 
@@ -193,7 +195,20 @@ def makedepends_of(pkgbuild):
         return depends
 
 
+def print_statistics():
+    with open("/build/logs/stats.dat", "w") as dat:
+        for n_deps, freq in dependency_frequencies.items():
+            print(str(freq) + " " + str(n_deps), file=dat)
+            dat.flush()
+
+
 def ninja_builds_for(abs_dir):
+    """Outputs ninja build rules for the packages built from abs_dir.
+
+    Arguments:
+        abs_dir: Path to an ABS build directory (e.g.
+        "/var/abs/core/glibc").
+    """
     pkgbuild = abs_dir + "/PKGBUILD"
     target_packages = pkgnames_of(pkgbuild)
     if not target_packages: return
@@ -213,6 +228,11 @@ def ninja_builds_for(abs_dir):
         ninja.build(build_name, "phony", depends)
         ninja.output.flush()
 
+        n_deps = len(depends)
+        if not n_deps in dependency_frequencies:
+            dependency_frequencies[n_deps] = 0
+        dependency_frequencies[n_deps] += len(target_packages)
+
         number_of_packages.value += len(target_packages)
         counter.value += 1
         print("\r" + str(counter.value) + "/" + builds_len +
@@ -220,9 +240,23 @@ def ninja_builds_for(abs_dir):
               " packages found.", file=stderr, end="")
 
 
+def setup_argparse():
+    global args
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose",
+                        dest="verbose", action="store_true")
+    parser.add_argument("-t", "--statistics",
+                        dest="statistics", action="store_true")
+    args = parser.parse_args()
+
+
 def main():
     """This script should be run inside a container."""
-    global builds_len, ninja
+    global builds_len, ninja, dependency_frequencies
+
+    setup_argparse()
+
+    dependency_frequencies = Manager().dict()
 
     with open("/build/logs/build.ninja", "w") as log:
         ninja = Writer(log, 72)
@@ -235,10 +269,13 @@ def main():
         builds = glob("/var/abs/*/*")
         builds = [b for b in builds if not excluded(b)]
         builds_len = str(len(builds))
+
         with Pool(cpu_count()) as p:
             p.map(ninja_builds_for, builds)
-
         print("", file=stderr)
+
+        if args.statistics:
+            print_statistics()
 
 
 # Globals, referenced from spawned processes. Remember to initialize
@@ -248,6 +285,8 @@ number_of_packages = Value("i", 0)
 lock = Lock()
 builds_len = ""
 ninja = None
+dependency_frequencies = None
+args = None
 
 
 # Arch Linux packages in the 'base' group, i.e. expected to be installed


### PR DESCRIPTION
This commit makes the deps_to_ninja respect the VERBOSE environment
variable. Setting VERBOSE in the build environment causes the
deps_to_ninja container to print a dependency statistics graph when it
is run.
