### PR TITLE
Container for getting base package names

### DIFF
--- a/get_base_package_names/Dockerfile
+++ b/get_base_package_names/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Arch Linux container for building all dependencies of all Arch Linux
+# packages.
+#
+# USAGE:
+#   docker run container_name
+
+FROM karkhaz/arch-tuscan:latest
+MAINTAINER Kareem Khazem <khazem@google.com>
+
+COPY get_base_package_names.py /build/get_base_package_names.py
+COPY utilities.py /build/utilities.py
+
+ENTRYPOINT ["/usr/bin/python", "-u", "/build/get_base_package_names.py"]

--- a/get_base_package_names/get_base_package_names.py
+++ b/get_base_package_names/get_base_package_names.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from utilities import OutputDirectory, setup_argparse
+
+from subprocess import run, PIPE
+from sys import stderr
+
+
+def package_list(group):
+    """Get the packages in group 'group'."""
+    ret = run(["pacman", "--query", "--groups", group],
+              stdout=PIPE, universal_newlines=True)
+    if ret.returncode:
+        print("Pacman failed to query group " + group, file=stderr)
+        exit(1)
+
+    lst = []
+
+    for line in ret.stdout.splitlines():
+        pair = line.split(" ")
+        if not len(pair) == 2:
+            print("Bad output from pacman: " + line, file=stderr)
+            exit(1)
+        lst.append(pair[1])
+
+    return lst
+
+
+def format_as_python(package_list, name):
+    ret = name + " = ["
+    for pack in package_list:
+        ret += "\"" + pack + "\", "
+    return ret + "]"
+
+
+def main():
+    args = setup_argparse()
+
+    base_list = package_list("base")
+    base_devel_list = package_list("base-devel")
+
+    with OutputDirectory(args, __file__) as out_dir:
+        with open(out_dir + "/names.py", "w") as names:
+            print(format_as_python(base_list, "base"),
+                  file=names)
+            print(format_as_python(base_devel_list, "base_devel"),
+                  file=names)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/get_base_package_names.py
+++ b/test/get_base_package_names.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from os.path import exists
+from subprocess import run, DEVNULL
+from sys import path
+
+class TestGetBasePackageNames(unittest.TestCase):
+
+    def test_shared_data_exists(self):
+        self.assertTrue(
+            exists("/tuscan_data/"))
+
+    def test_top_level_exists(self):
+        self.assertTrue(
+            exists("/tuscan_data/get_base_package_names/"))
+
+    def test_latest_exists(self):
+        self.assertTrue(
+            exists("/tuscan_data/get_base_package_names/latest/"))
+
+    def test_names_file_exists(self):
+        self.assertTrue(
+            exists("/tuscan_data/get_base_package_names/latest/names.py"))
+
+    def test_can_import_names(self):
+        path.insert(0, "/tuscan_data/get_base_package_names/latest/")
+        from names import base
+        from names import base_devel
+
+    def test_names_are_packages(self):
+        path.insert(0, "/tuscan_data/get_base_package_names/latest/")
+        from names import base
+        from names import base_devel
+        for pack in base:
+            ret = run(["pacman", "--query", "--info", pack],
+                      stdout=DEVNULL, universal_newlines=True)
+            self.assertEqual([pack, ret.returncode],
+                             [pack, 0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit introduces a container that retrieves the names of Arch
Linux packages in the base and base-devel groups. It dumps them as two
lists in a python file, which can be imported by other scripts.

This commit also contains a test suite for this container.
