### PR TITLE
Using common base container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ $(call build_marker,$(TEST)): $(call dockerfile,$(TEST))       \
 
 $(call pull_marker,$(ARCH_PULL)):
 	@$(ECHO) Retrieving Arch Linux image
-	@docker pull base/arch:latest $(VERBOSE)
+	@docker pull karkhaz/arch-tuscan:latest $(VERBOSE)
 	$(call touch,$@)
 
 

--- a/deps_to_ninja/Dockerfile
+++ b/deps_to_ninja/Dockerfile
@@ -19,22 +19,8 @@
 # USAGE:
 #   docker run container_name
 
-FROM base/arch:latest
+FROM karkhaz/arch-tuscan:latest
 MAINTAINER Kareem Khazem <khazem@google.com>
-
-# Make sure everything is up to date
-RUN pacman-key  --refresh-keys
-RUN pacman -Syyu --needed --noconfirm
-RUN pacman-db-upgrade
-
-# Install needed software
-RUN pacman -Syu --needed --noconfirm base-devel
-RUN pacman -Syu --needed --noconfirm base
-RUN pacman -Syu --needed --noconfirm python
-RUN pacman -Syu --needed --noconfirm abs
-
-# Sync Arch Build System repository
-RUN abs
 
 COPY deps_to_ninja.py /build/deps_to_ninja.py
 COPY ninja_syntax.py /build/ninja_syntax.py

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -15,17 +15,7 @@
 # limitations under the License.
 
 
-FROM base/arch:latest
+FROM karkhaz/arch-tuscan:latest
 MAINTAINER Kareem Khazem <khazem@google.com>
-
-# Make sure everything is up to date
-RUN pacman-key  --refresh-keys
-RUN pacman -Syyu --needed --noconfirm
-RUN pacman-db-upgrade
-
-# Install needed software
-RUN pacman -Syu --needed --noconfirm base-devel
-RUN pacman -Syu --needed --noconfirm base
-RUN pacman -Syu --needed --noconfirm python
 
 COPY . /test


### PR DESCRIPTION
This commit causes all directories to pull in the arch-tuscan container
located at

https://hub.docker.com/r/karkhaz/arch-tuscan/

instead of the default Arch Linux container. This reduces duplicated
work, especially when running tests on travis.
