### PR TITLE
Output stored in data container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 *.pyc
-output
 __pycache__
-build.ninja
 .ninja_deps
 .ninja_log
 .deps_to_ninja_container_marker
 .pull_arch
+.test_*
+.tuscan_data_container_marker

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 python:
   - "3.5"
 
-script: STATISTICS="yes" make -j test
+script: VERBOSE=yes make -j test
 
 services:
   - docker

--- a/deps_to_ninja/deps_to_ninja.py
+++ b/deps_to_ninja/deps_to_ninja.py
@@ -76,10 +76,12 @@ packages are not rebuilt unnecessarily.
 """
 
 from argparse import ArgumentParser
+from datetime import datetime
 from glob import glob
 from multiprocessing import Value, Lock, Pool, cpu_count, Manager
 from ninja_syntax import Writer
-from os import linesep
+from os import linesep, makedirs, remove, symlink
+from os.path import basename, lexists, splitext
 from re import sub
 from subprocess import PIPE, Popen, TimeoutExpired, run
 from sys import stderr, stdout, argv
@@ -195,8 +197,8 @@ def makedepends_of(pkgbuild):
         return depends
 
 
-def print_statistics():
-    with open("/build/logs/stats.dat", "w") as dat:
+def print_statistics(out_dir):
+    with open(out_dir + "/stats.dat", "w") as dat:
         for n_deps, freq in dependency_frequencies.items():
             print(str(freq) + " " + str(n_deps), file=dat)
             dat.flush()
@@ -240,42 +242,59 @@ def ninja_builds_for(abs_dir):
               " packages found.", file=stderr, end="")
 
 
-def setup_argparse():
-    global args
-    parser = ArgumentParser()
-    parser.add_argument("-v", "--verbose",
-                        dest="verbose", action="store_true")
-    parser.add_argument("-t", "--statistics",
-                        dest="statistics", action="store_true")
-    args = parser.parse_args()
+class OutputDirectory():
+    def __init__(self, args):
+        top_level = splitext(basename(__file__))[0]
+        self.top_level = args.shared_directory + "/" + top_level
+
+        timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        self.path = self.top_level + "/" + timestamp
+
+    def __enter__(self):
+        makedirs(self.path, exist_ok=True)
+        return self.path
+
+    def __exit__(self, type, value, traceback):
+        latest = self.top_level + "/latest"
+        if lexists(latest):
+            remove(latest)
+        symlink(self.path, latest)
 
 
 def main():
     """This script should be run inside a container."""
     global builds_len, ninja, dependency_frequencies
 
-    setup_argparse()
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--verbose",
+                        dest="verbose", action="store_true")
+    parser.add_argument("-t", "--statistics",
+                        dest="statistics", action="store_true")
+    parser.add_argument("-d", "--shared-directory",
+                        dest="shared_directory", action="store")
+    args = parser.parse_args()
 
     dependency_frequencies = Manager().dict()
 
-    with open("/build/logs/build.ninja", "w") as log:
-        ninja = Writer(log, 72)
+    with OutputDirectory(args) as out_dir:
+        with open(out_dir + "/build.ninja", "w") as log:
+            ninja = Writer(log, 72)
 
-        ninja.rule("makepkg", "cd /var/abs/${in} && makepkg")
-        ninja.rule("phony", "# phony ${out}")
+            ninja.rule("makepkg", "cd /var/abs/${in} && makepkg")
+            ninja.rule("phony", "# phony ${out}")
 
-        log.flush()
+            log.flush()
 
-        builds = glob("/var/abs/*/*")
-        builds = [b for b in builds if not excluded(b)]
-        builds_len = str(len(builds))
+            builds = glob("/var/abs/*/*")
+            builds = [b for b in builds if not excluded(b)]
+            builds_len = str(len(builds))
 
-        with Pool(cpu_count()) as p:
-            p.map(ninja_builds_for, builds)
-        print("", file=stderr)
+            with Pool(cpu_count()) as p:
+                p.map(ninja_builds_for, builds)
+            print("", file=stderr)
 
-        if args.statistics:
-            print_statistics()
+            if args.statistics:
+                print_statistics(out_dir)
 
 
 # Globals, referenced from spawned processes. Remember to initialize
@@ -286,7 +305,6 @@ lock = Lock()
 builds_len = ""
 ninja = None
 dependency_frequencies = None
-args = None
 
 
 if __name__ == "__main__":

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,33 @@
+# vim: set syntax=dockerfile:
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+FROM base/arch:latest
+MAINTAINER Kareem Khazem <khazem@google.com>
+
+# Make sure everything is up to date
+RUN pacman-key --refresh-keys
+RUN pacman -Syyu --needed --noconfirm
+RUN pacman-db-upgrade
+
+# Install needed software
+RUN pacman -Syu --needed --noconfirm base-devel
+RUN pacman -Syu --needed --noconfirm base
+RUN pacman -Syu --needed --noconfirm python
+
+COPY . /test
+
+CMD ["/usr/bin/true"]

--- a/test/deps_to_ninja.py
+++ b/test/deps_to_ninja.py
@@ -1,0 +1,1 @@
+#!/usr/bin/python3


### PR DESCRIPTION
Output from containers is no longer stored locally, but rather written
to a data container. This is to facilitate sharing of data between
containers, and running tests on container output.

A test container is also committed. A test suite called test/foo.py is
intended to test the output of container foo.
