### PR TITLE
added make_package stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ container_build_dir
 
 deps
 
-build.ninja
+makepkg.ninja
 tuscan.ninja
 
 .ninja_deps

--- a/data_containers.yaml
+++ b/data_containers.yaml
@@ -3,13 +3,14 @@
 - 
   name: tuscan_data
   mountpoint: /tuscan_data
-  switch: --shared-directory
+  switch: shared
 
 - 
   name: sources
   mountpoint: /sources
-  switch: --sources-directory
+  switch: sources
 
 - 
-  name: pkg_cache___TOOLCHAIN__
-  mountpoint: /var/abs/cache/pacman/pkg/
+  name: pkg_cache_$TOOLCHAIN
+  mountpoint: /var/cache/pacman/pkg/
+  switch: pkg-cache

--- a/package_build_wrapper.py
+++ b/package_build_wrapper.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python2
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from argparse import ArgumentParser
+from json import dumps, load
+from re import compile, match
+from subprocess import Popen, PIPE, STDOUT
+from sys import stderr
+from time import gmtime, mktime
+
+
+def run_container(args):
+    stderr.write("Running container for " + args.target_package)
+    start_time = mktime(gmtime())
+    command = ("docker run -v " + args.shared_directory
+               + " --volumes-from " + args.data_volume
+               + " -v " + args.sources_directory
+               + " --volumes-from " + args.sources_volume
+               + " -v /var/cache/pacman/pkg"
+               + " --volumes-from " + args.pkg_cache_volume
+               + " -v logs:/logs make_package"
+               + " --sources-directory " + args.sources_directory
+               + " --shared-directory "  + args.shared_directory
+               + " " + args.target_package)
+    p = Popen(command.split(), universal_newlines=True, stdout=PIPE,
+              stderr=STDOUT)
+    out, _ = p.communicate()
+    rc = p.returncode
+
+    json_result = {}
+    json_result["return_code"] = p.returncode
+    json_result["log"] = [command] + out.splitlines()
+    json_result["package"] = args.target_package
+    json_result["time"] = int(mktime(gmtime()) - start_time)
+
+    for touch_file in args.output_packages:
+        with open(touch_file, "w") as f:
+            f.write(dumps(json_result, sort_keys=True, indent=2,
+                          separators=(",", ": ")))
+            f.flush()
+
+
+def main():
+    parser = ArgumentParser(description=
+                "Attempt to build a single package.")
+
+    parser.add_argument("--shared-directory", dest="shared_directory",
+                        action="store", required=True)
+    parser.add_argument("--shared-volume", dest="data_volume",
+                        action="store", required=True)
+    parser.add_argument("--sources-directory", dest="sources_directory",
+                        action="store", required=True)
+    parser.add_argument("--sources-volume", dest="sources_volume",
+                        action="store", required=True)
+    parser.add_argument("--target-package", dest="target_package",
+                        action="store", required=True)
+    parser.add_argument("--pkg-cache-volume", dest="pkg_cache_volume",
+                        action="store", required=True)
+    parser.add_argument("--output-directory", dest="output_directory",
+                        action="store", required=True)
+    parser.add_argument("output_packages", action="store", nargs="+")
+
+    args = parser.parse_args()
+
+    run_container(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/stages/custom_repository/deps.yaml
+++ b/stages/custom_repository/deps.yaml
@@ -5,19 +5,19 @@ build:
 
 run:
   dependencies:
-    experiments:
+    stages:
       - get_base_package_names
     data_containers:
       - tuscan_data
       - sources
-      - pkg_cache___TOOLCHAIN__
+      - pkg_cache_$TOOLCHAIN
 
   stdout: .names
   post_exit: >
                while read name; do
                export ns=$(echo $name | tr -d '\r');
-               mkdir -p __TOUCH_DIR__/pkgbuild_markers;
+               mkdir -p $TOUCH_DIR/pkgbuild_markers;
                cat tuscan/empty.json
                | sed "s/__PACKAGE/$ns/g"
-               > "__TOUCH_DIR__/pkgbuild_markers/$ns";
+               > "$TOUCH_DIR/pkgbuild_markers/$ns";
                done < .names

--- a/stages/deps_to_ninja/deps_to_ninja.py
+++ b/stages/deps_to_ninja/deps_to_ninja.py
@@ -328,25 +328,21 @@ def main():
 
     ninja  = Writer(stdout, 72)
 
-    for outs, rule, ins in global_builds:
-        ninja.build(outs, rule, ins)
-
     ninja.rule("makepkg", "./package_build_wrapper.py"
          + " --shared-directory " + args.shared_directory
+         + " --shared-volume " + args.shared_volume
          + " --sources-directory " + args.sources_directory
+         + " --sources-volume " + args.sources_volume
+         + " --pkg-cache-volume " + args.pkg_cache_volume
          + " --output-directory " + args.output_directory
          + " --target-package ${in}"
          + " ${out}"
-         + " && report_gen/single_package_report.py"
-         + " --toolchain " + args.toolchain
-         + " --package ${in}"
     )
 
-    stdout.flush()
+    for outs, rule, ins in global_builds:
+        ninja.build(outs, rule, ins)
 
-    for dep in global_deps:
-        print(dep, file=stderr)
-    stderr.flush()
+    stdout.flush()
 
 
 if __name__ == "__main__":

--- a/stages/make_package/deps.yaml
+++ b/stages/make_package/deps.yaml
@@ -1,18 +1,18 @@
 ---
 build:
   copy_files:
-    - tuscan/ninja_syntax.py
+    - toolchains/$TOOLCHAIN/makepkg.conf
+    - toolchains/$TOOLCHAIN/Dockerfile
     - tuscan/utilities.py
-    - tuscan/provides.json
 
 run:
   dependencies:
     stages:
-      - get_base_package_names
+      - custom_repository
+      - deps_to_ninja
     data_containers:
       - tuscan_data
       - sources
       - pkg_cache_$TOOLCHAIN
 
-  stdout: makepkg.ninja
-  stderr: deps
+  command_override: ninja -f makepkg.ninja

--- a/stages/make_package/make_package.py
+++ b/stages/make_package/make_package.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from utilities import get_argparser
+
+from fnmatch import filter
+from logging import basicConfig, info, DEBUG
+from os import chdir, listdir, walk
+from os.path import isdir, isfile, join
+from re import search, sub
+from shutil import chown, copytree, rmtree
+from subprocess import run, PIPE, STDOUT
+
+
+def die(success):
+    info("Printing config.logs")
+    config_logs = []
+    for root, dirs, files in walk("/tmp"):
+        for log in files:
+            if log == "config.log":
+                debug("found log at %s" % join(root, log))
+                config_logs.append(join(root, log))
+
+    for log in config_logs:
+        debug("File %s" % log)
+        with open(log, encoding="utf-8") as f:
+            debug(str(f.read()))
+
+    debug("Finished printing config.logs")
+
+    if success:
+        exit(0)
+    else:
+        exit(1)
+
+
+def recursive_chown(directory):
+    """makepkg cannot be run as root.
+
+    This function changes the owner and group owner of a directory tree
+    rooted at directory to "tuscan".
+    """
+    chown(directory, "tuscan", "tuscan")
+    for path, subdirs, files in walk(directory):
+        for f in subdirs + files:
+            chown(join(path, f), "tuscan", "tuscan")
+
+
+def get_package_source_dir(package, sources_directory):
+    """Get the sources for a package.
+
+    PKGBUILDs contain instructions for downloading sources and then
+    building them. We don't want to download the sources before every
+    build, so this function downloads sources and stores them in a
+    standard location so that they can be copied later rather than
+    re-downloaded.
+
+    If this function returns successfully, the abs directory for package
+    will have been copied to sources_directory, and the sources for that
+    package will have been downloaded into it.
+    """
+    abs_dir = None
+    for repo in ["core", "extra", "community"]:
+        if isdir(join("/var/abs/", repo, package)):
+            if abs_dir:
+                debug("Found duplicate package '%s' in both %s and %s" %
+                      (package, repo, abs_dir))
+                die(False)
+            else:
+                abs_dir = join("/var/abs/", repo, package)
+    if not abs_dir:
+        debug("Could not find abs directory for package '%s'" % package)
+    package_source_dir = join(sources_directory, package)
+    copytree(abs_dir, package_source_dir)
+    recursive_chown(package_source_dir)
+    chdir(package_source_dir)
+    # The --nobuild flag to makepkg causes it to download sources, but
+    # not build them.
+    command = ("sudo -u tuscan makepkg --nobuild --syncdeps "
+               "--skipinteg --skippgpcheck --skipchecksums "
+               "--noconfirm --nocolor --log --noprogressbar "
+               "--nocheck")
+    debug(command)
+    cp = run(command.split(), stdout=PIPE, stderr=STDOUT,
+             universal_newlines=True)
+
+    for line in (cp.stdout.splitlines()):
+        debug(line)
+
+    ret_code = False
+    if cp.returncode:
+        rmtree(package_source_dir)
+    else:
+        ret_code = True
+
+    return ret_code
+
+
+def copy_and_build(args):
+    permanent_source_dir = join(args.sources_directory,
+                                args.package_name)
+    build_dir = join("/tmp/", args.package_name)
+
+    copytree(permanent_source_dir, build_dir)
+    recursive_chown(build_dir)
+    chdir(build_dir)
+
+    # Add the --host option to invocations of ./configure
+    with open("PKGBUILD", encoding="utf-8") as f:
+        pkgbuild = f.readlines()
+
+    pkgbuild = [sub(r"configure\s",
+                    "configure --host x86_64-unknown-linux ",
+                    line) for line in pkgbuild]
+
+    with open("PKGBUILD", "w", encoding="utf-8") as f:
+        f.write("\n".join(pkgbuild))
+
+    # The difference between this invocation and the one in
+    # get_package_source_dir() is the --noextract flag. Sources should
+    # already have been downloaded and extracted by
+    # get_package_source_dir(), so we just want to build them.
+    if args.env_vars == None:
+        args.env_vars = []
+    command = (
+       "sudo -u tuscan %s"
+       " makepkg --noextract --syncdeps"
+       " --skipinteg --skippgpcheck --skipchecksums"
+       " --noconfirm --nocolor --log --noprogressbar"
+       " --nocheck"
+       % (" ".join(args.env_vars))
+    )
+    debug(command)
+    cp = run(command.split(), stdout=PIPE, stderr=STDOUT,
+             universal_newlines=True)
+    for line in (cp.stdout.splitlines()):
+        debug(line)
+
+    if cp.returncode:
+        die(False)
+    else:
+        die(True)
+
+
+def sanity_checks(args):
+    cache_files = listdir("/var/cache/pacman/pkg")
+    debug("Found %d packages in cache" % len(cache_files))
+
+    if not isdir(args.sources_directory):
+        debug("Could not find source directory '%s'" %
+              args.sources_directory)
+        die(False)
+
+    permanent_source_dir = join(args.sources_directory,
+                                args.package_name)
+    if not isdir(permanent_source_dir):
+        if not(get_package_source_dir(args.package_name,
+                                      args.sources_directory)):
+            debug("Unable to get sources for package '%s'" %
+                  args.package_name)
+            die(False)
+        else:
+            debug("Copied source directory to '%s'" %
+                  permanent_source_dir)
+    else:
+        debug("Found permanent source directory in %s" %
+              permanent_source_dir)
+
+
+def force_synchronise_repository():
+    """Synchronise pacman with local repository
+
+    A local repository should have been built by the container
+    custom_repository; that container should also have disabled remote
+    repositories. This function synchronises pacman to the local
+    repository.
+    """
+    cp = run(["pacman", "-Syy"], stdout=PIPE, stderr=STDOUT,
+             universal_newlines=True)
+    # If that failed, then either the repository wasn't built correctly
+    # (a problem with the custom_repository container) or there is
+    # something wrong with the Dockerfile of this container.
+    if cp.returncode:
+        for line in cp.stdout.splitlines() + cp.stderr.splitlines():
+            debug(line)
+        die(False)
+    for line in (cp.stdout.splitlines()):
+        debug(line)
+
+
+def main():
+    parser = get_argparser()
+    parser.add_argument("package_name")
+    args = parser.parse_args()
+
+    basicConfig(format="tuscan: %(message)s", level=DEBUG)
+
+    sanity_checks(args)
+    force_synchronise_repository()
+
+    result = copy_and_build(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tuscan.py
+++ b/tuscan.py
@@ -22,8 +22,33 @@ from os import getcwd, listdir
 from os.path import dirname, isfile, join
 from re import sub
 from subprocess import call
+from string import Template
 from sys import stdout, stderr
 from yaml import load
+
+
+def substitute_vars(data_structure, args):
+    """Substitute variables in YAML data files with values.
+
+    Data stored in YAML files can contain variables which need to be
+    resolved at runtime. This method returns the dict or list passed in
+    as the data_structure argument, with all substitutions applied.
+    """
+    if isinstance(data_structure, basestring):
+        ret = Template(data_structure)
+        ret.substitute(TOOLCHAIN=args.toolchain)
+        ret.substitute(TOUCH_DIR=args.touch_dir)
+    elif isinstance(data_structure, list):
+        ret = []
+        for e in data_structure:
+            ret.append(substitute_vars(e, args))
+    elif isinstance(data_structure, dict):
+        ret = {}
+        for k, v in data_structure.items():
+            ret[k] = substitute_vars(v, args)
+    else: raise RuntimeError("Impossible type with value " +
+                             str(data_structure))
+    return ret
 
 
 def run_ninja(args, ninja_file):
@@ -47,7 +72,7 @@ def create_build_file(args, ninja):
     stages.write_build_recipies()
 
     # The top-level build rule
-    ninja.build("build", "phony", touch("run", "custom_repository",
+    ninja.build("build", "phony", touch("run", "make_package",
                                         args))
 
 
@@ -73,10 +98,7 @@ class DataContainers(object):
                          " 'data_containers.yaml'.\n")
             exit(1)
 
-        self.containers = containers
-        for cont in containers:
-            cont["name"] = sub("__TOOLCHAIN__", args.toolchain,
-                               cont["name"])
+        self.containers = substitute_vars(containers, self.args)
         self.data_container_sanity_checks()
 
 
@@ -151,7 +173,7 @@ class Stages(object):
                              " contain a deps.yaml file.\n")
                 exit(1)
 
-        self.stages = stages
+        self.stages = substitute_vars(stages, self.args)
         self.normalise_containers()
         self.container_sanity_checks()
 
@@ -177,33 +199,42 @@ class Stages(object):
 
             commands = []
 
-            docker = "docker run --rm "
+            if "command_override" in sta["run"]:
+                main_command = sta["run"]["command_override"]
+            else:
+                main_command = "docker run --rm "
 
-            for cont in data_containers_needed_by(sta,
-                            self.data_containers):
-                docker += "-v " + cont["mountpoint"]
-                docker += " --volumes-from " + cont["name"] + " "
+                for cont in data_containers_needed_by(sta,
+                                self.data_containers):
+                    main_command += "-v " + cont["mountpoint"]
+                    main_command += " --volumes-from " + cont["name"]
+                    main_command += " "
 
-            docker += " -t " + sta["name"]
-            docker += " --output-directory " + self.args.touch_dir
-            docker += " --toolchain " + self.args.toolchain
+                main_command += " -t " + sta["name"]
+                main_command += " --output-directory "
+                main_command += self.args.touch_dir
+                main_command += " --toolchain " + self.args.toolchain
 
-            for cont in data_containers_needed_by(sta,
-                            self.data_containers):
-                if "switch" in cont:
-                    docker += (" " + cont["switch"] +
-                               " " + cont["mountpoint"])
+                for cont in data_containers_needed_by(sta,
+                                self.data_containers):
+                    if "switch" in cont:
+                        main_command += (" --" + cont["switch"] +
+                                         "-directory "
+                                         + cont["mountpoint"])
+
+                        main_command += (" --" + cont["switch"] +
+                                         "-volume "
+                                         + cont["name"])
 
             if sta["run"]["stdout"]:
-                docker += " >" + sta["run"]["stdout"]
+                main_command += " >" + sta["run"]["stdout"]
             if sta["run"]["stderr"]:
-                docker += " 2>" + sta["run"]["stderr"]
+                main_command += " 2>" + sta["run"]["stderr"]
 
-            commands.append(docker)
+            commands.append(main_command)
 
             if "post_exit" in sta["run"]:
                 cmd = sta["run"]["post_exit"]
-                cmd = sub("__TOUCH_DIR__", self.args.touch_dir, cmd)
                 cmd = sub("\$", "$$", cmd)
                 commands.append(cmd.strip())
 
@@ -291,12 +322,6 @@ class Stages(object):
 
             if not "data_containers" in sta["run"]["dependencies"]:
                 sta["run"]["dependencies"]["data_containers"] = []
-
-            tmp = []
-            for cont in sta["run"]["dependencies"]["data_containers"]:
-                tmp.append(sub("__TOOLCHAIN__", self.args.toolchain,
-                           cont))
-            sta["run"]["dependencies"]["data_containers"] = tmp
 
             if not "stages" in sta["run"]["dependencies"]:
                 sta["run"]["dependencies"]["stages"] = []

--- a/tuscan/utilities.py
+++ b/tuscan/utilities.py
@@ -80,11 +80,26 @@ def get_argparser():
                         dest="verbose", action="store_true")
     parser.add_argument("--output-directory",
                         dest="output_directory", action="store")
+
     parser.add_argument("--shared-directory",
                         dest="shared_directory", action="store")
+    parser.add_argument("--shared-volume",
+                        dest="shared_volume", action="store")
+
     parser.add_argument("--sources-directory",
                         dest="sources_directory", action="store")
+    parser.add_argument("--sources-volume",
+                        dest="sources_volume", action="store")
+
+    parser.add_argument("--pkg-cache-directory",
+                        dest="pkg_cache_directory", action="store")
+    parser.add_argument("--pkg-cache-volume",
+                        dest="pkg_cache_volume", action="store")
+
     parser.add_argument("--toolchain",
                         dest="toolchain", action="store")
+
+    parser.add_argument("--env-vars", nargs="*",
+                        dest="env_vars", action="store")
 
     return parser


### PR DESCRIPTION
## Summary:
- Added make_package stage
- Added package_build_wrapper.py
- tuscan.py: variable substitutions now performed over entire YAML file
- tuscan.py: implemented command_override
- data containers: changed representation in YAML file
## Details:

This commit introduces the make_package stage. This stage is not called
directly from tuscan.py like the other stages. Rather, it is called
(once for each package) from the ninja file output by the deps_to_ninja
stage. The actual invocation of the make_package stage is wrapped up in
the package_build_wrapper.py script.

This stage required several changes to the data representation:
- Several aspects of YAML files are now parametric over the toolchain.
  Thus, tuscan.py now globally substitutes all instances of
  **TOOLCHAIN** with the toolchain name, rather than in just one key.
- Since the make_package stage is not invoked from tuscan.py, the
  command_override key was introduced to facilitate invoking that stage.
- The data containers YAML file has been refactored to move even more
  data away from tuscan.py, and for better consistency. In particular,
  if a data container specifies its switch name as "foo", then
  containers will always be passed that data container's name as
  --foo-volume and the data container's mountpoint as --foo-directory.
  This is necessary in this commit to ensure that the make_package stage
  uses consistent naming with respect to all the other stages.
