### PR TITLE
Error classification of log files

### DIFF
--- a/tuscan/classification_patterns.yaml
+++ b/tuscan/classification_patterns.yaml
@@ -1,0 +1,61 @@
+---
+- 
+  pattern: ": (?P<file>.+?): cannot execute binary file"
+  category: "exec_error"
+- 
+  pattern: "cannot execute binary file: (?P<file>.+)"
+  category: "exec_error"
+- 
+  pattern: "configure: error: (?P<error>.+)"
+  category: "configure_error"
+- 
+  pattern: "tuscan: configure log has no return code"
+  category: "unparseable_config"
+- 
+  pattern: "[-\\.\\w\\g+]+.(S|s):\\d+: (E|e)rror: (?P<error>.+)"
+  category: "assembler_error"
+- 
+  pattern: "[-\\.\\w\\+\\/]+:\\d+:\\d+: error:"
+  category: "compile_error"
+- 
+  pattern: "ld: error: cannot find (?P<library>.+)"
+  category: "link_error"
+- 
+  pattern: "(?P<header>[-.\\w\\/]+\\.h): No such file or directory"
+  category: "missing_header"
+- 
+  pattern: "==> ERROR: Failure while downloading"
+  category: "missing_source"
+- 
+  pattern: "error: target not found: (?P<dependency>[-\\.\\w]+)"
+  category: "missing_deps"
+- 
+  pattern: "error: undefined reference to '(?P<symbol>.+)'"
+  category: "undefined_reference"
+- 
+  pattern: "tuscan: native invocation of '(?P<tool>\\w+)'"
+  category: "native_tool_invocation"
+- 
+  pattern: "(?P<command>[-\\.\\+\\gw]+): command not found"
+  category: "command_not_found"
+- 
+  pattern: "gcc: error: unrecognized command line option '(?P<flag>.+)'"
+  category: "unknown_compiler_flag"
+- 
+  pattern: "gcc: error: unrecognized argument in option '(?P<flag>.+)'"
+  category: "unknown_compiler_flag"
+- 
+  pattern: "Unrecognized option : ((--host)|(x86_64-unknown-linux))"
+  category: "host_flag_unrecognised"
+- 
+  pattern: "configure: unknown option --host"
+  category: "host_flag_unrecognised"
+- 
+  pattern: "unknown option: --host"
+  category: "host_flag_unrecognised"
+- 
+  pattern: "rm: cannot remove"
+  category: "install_error"
+- 
+  pattern: "mv: cannot stat"
+  category: "install_error"

--- a/tuscan/tuscan_postprocess.py
+++ b/tuscan/tuscan_postprocess.py
@@ -26,6 +26,7 @@ the schemata in tuscan/schemata.py.
 
 
 from tuscan.schemata import make_package_schema, post_processed_schema
+from tuscan.schemata import classification_schema
 
 from functools import partial
 from json import load, dump
@@ -33,16 +34,54 @@ from multiprocessing import Pool
 from voluptuous import MultipleInvalid
 from os import listdir, makedirs, unlink
 from os.path import basename, isdir, join
+from re import search
 from signal import signal, SIGINT
 from sys import stderr
 from time import sleep
+from yaml import load
 
 
-def process_single_result(data, args):
+def process_log_line(line, patterns):
+    ret = {"text": line, "category": None, "semantics": {}}
+    for err_class in patterns:
+        m = search(err_class["pattern"], line)
+        if m:
+            ret["category"] = err_class["category"]
+            for k, v in m.groupdict().iteritems():
+                ret["semantics"][k] = v
+            break
+    return ret
+
+
+def process_single_result(data, patterns):
+    # Classify errors in each line of the output of commands. The format
+    # is in post_processed_schema["log"]["body"].
+    new_log = []
+    for obj in data["log"]:
+        new_body = []
+        for line in obj["body"]:
+            new_body.append(process_log_line(line, patterns))
+        obj["body"] = new_body
+        new_log.append(obj)
+    data["log"] = new_log
+
+    # Now, count how many of each type of error were accumulated for
+    # this package.
+    category_counts = {}
+    for obj in data["log"]:
+        for line in obj["body"]:
+            cat = line["category"]
+            try:
+                category_counts[cat] += 1
+            except KeyError:
+                category_counts[cat] = 1
+    category_counts.pop(None, None)
+    data["category_counts"] = category_counts
+
     return data
 
 
-def load_and_process(path, out_dir, args):
+def load_and_process(path, out_dir, patterns):
     """Processes a JSON result file at path and dumps it to out_dir."""
     with open(path) as f:
         data = load(f)
@@ -54,7 +93,7 @@ def load_and_process(path, out_dir, args):
                      (path, str(e)))
         exit(1)
 
-    process_single_result(data, args)
+    process_single_result(data, patterns)
 
     try:
         post_processed_schema(data)
@@ -68,8 +107,18 @@ def load_and_process(path, out_dir, args):
 
 
 def do_postprocess(args):
+    with open("tuscan/classification_patterns.yaml") as f:
+        patterns = load(f)
+    try:
+        patterns = classification_schema(patterns)
+    except MultipleInvalid as e:
+        stderr.write("Classification pattern is malformatted: %s\n%s" %
+                     (str(e), str(patterns)))
+        exit(1)
+
     dst_dir = "post"
     src_dir = "results"
+
     for toolchain in listdir(src_dir):
         toolchain_dst = join(dst_dir, toolchain)
 
@@ -88,5 +137,5 @@ def do_postprocess(args):
         pool = Pool(args.pool_size)
         curry = partial(load_and_process,
                         out_dir=toolchain_dst,
-                        args=args)
+                        patterns=patterns)
         pool.map(curry, paths)


### PR DESCRIPTION
This commit introduces the ability to classify each line of the build
output as indicating some error. The post-processing pass now decorates
each line of the build output with its error category.
- classification_patterns.yaml contains the patterns that we attempt to
  match each line of the build output against, as well as what kind of
  error that line indicates if it matches.
- schemata.py has been updated to reflect the extra fields in the
  post-processed JSON.
