### PR TITLE
Flagging return codes of configure script logs

### DIFF
--- a/tuscan/classification_patterns.yaml
+++ b/tuscan/classification_patterns.yaml
@@ -2,60 +2,84 @@
 - 
   pattern: ": (?P<file>.+?): cannot execute binary file"
   category: "exec_error"
+  severity: error
 - 
   pattern: "cannot execute binary file: (?P<file>.+)"
   category: "exec_error"
+  severity: error
 - 
   pattern: "configure: error: (?P<error>.+)"
   category: "configure_error"
+  severity: error
 - 
   pattern: "tuscan: configure log has no return code"
   category: "unparseable_config"
+  severity: error
 - 
   pattern: "[-\\.\\w\\g+]+.(S|s):\\d+: (E|e)rror: (?P<error>.+)"
   category: "assembler_error"
+  severity: error
 - 
   pattern: "[-\\.\\w\\+\\/]+:\\d+:\\d+: error:"
   category: "compile_error"
+  severity: error
 - 
   pattern: "ld: error: cannot find (?P<library>.+)"
   category: "link_error"
+  severity: error
 - 
   pattern: "(?P<header>[-.\\w\\/]+\\.h): No such file or directory"
   category: "missing_header"
+  severity: error
 - 
   pattern: "==> ERROR: Failure while downloading"
   category: "missing_source"
+  severity: error
 - 
   pattern: "error: target not found: (?P<dependency>[-\\.\\w]+)"
   category: "missing_deps"
+  severity: error
 - 
   pattern: "error: undefined reference to '(?P<symbol>.+)'"
   category: "undefined_reference"
+  severity: error
 - 
   pattern: "tuscan: native invocation of '(?P<tool>\\w+)'"
   category: "native_tool_invocation"
+  severity: error
 - 
   pattern: "(?P<command>[-\\.\\+\\gw]+): command not found"
   category: "command_not_found"
+  severity: error
 - 
   pattern: "gcc: error: unrecognized command line option '(?P<flag>.+)'"
   category: "unknown_compiler_flag"
+  severity: error
 - 
   pattern: "gcc: error: unrecognized argument in option '(?P<flag>.+)'"
   category: "unknown_compiler_flag"
+  severity: error
 - 
   pattern: "Unrecognized option : ((--host)|(x86_64-unknown-linux))"
   category: "host_flag_unrecognised"
+  severity: error
 - 
   pattern: "configure: unknown option --host"
   category: "host_flag_unrecognised"
+  severity: error
 - 
   pattern: "unknown option: --host"
   category: "host_flag_unrecognised"
+  severity: error
 - 
   pattern: "rm: cannot remove"
   category: "install_error"
+  severity: error
 - 
   pattern: "mv: cannot stat"
   category: "install_error"
+  severity: error
+- 
+  pattern: "configure: exit (?P<return_code>\\d+)"
+  category: "configure_return_code"
+  severity: diagnostic

--- a/tuscan/schemata.py
+++ b/tuscan/schemata.py
@@ -127,6 +127,12 @@ post_processed_schema = Schema({
     Optional("toolchain"): _nonempty_string,
     Optional("errors"): list,
     Optional("bad_deps"): list,
+    # Status of all configure checks in this build, combined.
+    # If a single configure check returned non-zero, then False;
+    # If all configure checks returned zero, then True;
+    # If we couldn't figure out the return code of any configure check,
+    #    then None.
+    Required("config_success"): Any(bool, None),
     # This counts how many of each kind of error category were
     # encountered for this build. It is a map error_category =>
     # frequency, where the keys for error_category must be one of the
@@ -138,6 +144,12 @@ post_processed_schema = Schema({
         Schema({
             Required("head"): _nonempty_string,
             Required("kind"): Any("command", "info", "die"),
+            # If this log is a configure log, then this key reports on
+            # whether this invocation of config returned successfully.
+            # True if it did, False if it didn't, None if we weren't
+            # able to tell. This key does not exist in logs that are not
+            # config logs.
+            Optional("config_success"): Any(bool, None),
             Required("time"): (lambda s:
                 datetime.strptime(s, "%Y-%m-%dT%H:%M:%S")),
             # Post-processing looks through the output of commands, and
@@ -149,6 +161,7 @@ post_processed_schema = Schema({
             Required("body"): [Schema({
                 Required("text"): _string,
                 Required("category"): Any(_string, None),
+                Required("severity"): Any("error", "diagnostic", None),
                 Required("semantics"): Schema({
                     _nonempty_string: _nonempty_string
                 })
@@ -176,5 +189,6 @@ classification_schema = Schema([Schema({
     #     "category": "exec_error",
     #     "semantics": {"file": "./a.out"}}
     Required("pattern"): _nonempty_string,
-    Required("category"): _nonempty_string
+    Required("category"): _nonempty_string,
+    Required("severity"): Any("error", "diagnostic")
 })])

--- a/tuscan/tuscan_postprocess.py
+++ b/tuscan/tuscan_postprocess.py
@@ -34,7 +34,7 @@ from multiprocessing import Pool
 from voluptuous import MultipleInvalid
 from os import listdir, makedirs, unlink
 from os.path import basename, isdir, join
-from re import search
+from re import match, search
 from signal import signal, SIGINT
 from sys import stderr
 from time import sleep
@@ -42,11 +42,13 @@ from yaml import load
 
 
 def process_log_line(line, patterns):
-    ret = {"text": line, "category": None, "semantics": {}}
+    ret = {"text": line, "category": None, "semantics": {},
+           "severity": None}
     for err_class in patterns:
         m = search(err_class["pattern"], line)
         if m:
             ret["category"] = err_class["category"]
+            ret["severity"] = err_class["severity"]
             for k, v in m.groupdict().iteritems():
                 ret["semantics"][k] = v
             break
@@ -60,23 +62,38 @@ def process_single_result(data, patterns):
     for obj in data["log"]:
         new_body = []
         for line in obj["body"]:
-            new_body.append(process_log_line(line, patterns))
+            new_line = process_log_line(line, patterns)
+            if new_line["category"] == "configure_return_code":
+                rc = int(new_line["semantics"]["return_code"])
+                obj["config_success"] = False if rc else True
+            new_body.append(new_line)
         obj["body"] = new_body
         new_log.append(obj)
     data["log"] = new_log
 
     # Now, count how many of each type of error were accumulated for
-    # this package.
+    # this package. Also figure out if configure invocations were
+    # successful.
+    config_success = None
     category_counts = {}
     for obj in data["log"]:
+
+        if "config_success" in obj:
+            if not obj["config_success"]:
+                config_success = False
+            elif obj["config_success"] and config_success == None:
+                config_success = True
+
         for line in obj["body"]:
-            cat = line["category"]
-            try:
-                category_counts[cat] += 1
-            except KeyError:
-                category_counts[cat] = 1
+            if line["category"] != "configure_return_code":
+                cat = line["category"]
+                try:
+                    category_counts[cat] += 1
+                except KeyError:
+                    category_counts[cat] = 1
     category_counts.pop(None, None)
     data["category_counts"] = category_counts
+    data["config_success"] = config_success
 
     return data
 


### PR DESCRIPTION
Post-processed data now has the following two changes:
- The overall data has a required key called "config_success", which
  indicates whether the configure invocations for this build were all
  successful. This is so that we can distinguish between builds that
  failed during and after the configure stage.
- Each log fragment has an optional key called "config_success", which
  exists if that log fragment is a configure log (dumped by autoconf or
  the like). This is so that we can ignore 'errors' that happened during
  configure invocations that returned successfully, i.e. where the
  'errors' were actually expected.
