### PR TITLE
Dependencies of each build are logged for postproc

### DIFF
--- a/package_build_wrapper.py
+++ b/package_build_wrapper.py
@@ -109,6 +109,13 @@ def run_container(args):
                 # (transitively) can blame this build.
                 json_result["build_provides"] = obj["body"]
 
+            elif obj["kind"] == "dep_info":
+                # This list is returned by the make_package stage to
+                # tell us what packages are depended on by the build. If
+                # the build fails, we can use this list to check if any
+                # of the dependencies have also failed.
+                json_result["build_depends"] = obj["body"]
+
             else:
                 json_result["log"].append(obj)
 

--- a/stages/make_package/main.py
+++ b/stages/make_package/main.py
@@ -361,7 +361,7 @@ def create_hybrid_packages(args):
 
 
 def dump_build_information(args):
-    """Log the packages provided by this build
+    """Log the packages provided & depended on by this build
 
     This function logs all packages that will be built if this build
     succeeds. This includes 'virtual' packages, i.e. packages like 'sh'
@@ -370,6 +370,8 @@ def dump_build_information(args):
     This is so that if this build fails, any build that depends on a
     package provided by this build knows who to blame when it can't
     install its dependencies.
+
+    This function also logs what packages are depended on by this build.
     """
     pkgbuild = join(args.abs_dir, "PKGBUILD")
     provides = []
@@ -380,6 +382,16 @@ def dump_build_information(args):
 
     log("provide_info", None, output=provides)
 
+    depends = []
+    depends += [strip_version_info(name)
+        for name in interpret_bash_array(pkgbuild, "depends")]
+    depends += [strip_version_info(name)
+        for name in interpret_bash_array(pkgbuild, "makedepends")]
+
+    log("dep_info", "This build depends on the following packages",
+            output=depends)
+
+
 
 def main():
     parser = get_argparser()
@@ -387,14 +399,14 @@ def main():
     args = parser.parse_args()
     args.mirror_directory = "/mirror"
 
+    dump_build_information(args)
+
     pkg_dir = basename(args.abs_dir)
 
     args.permanent_source_dir = join(args.sources_directory, pkg_dir)
     args.build_dir = join("/tmp", pkg_dir)
 
     sanity_checks(args)
-
-    dump_build_information(args)
 
     initialize_repositories(args)
 

--- a/tuscan/schemata.py
+++ b/tuscan/schemata.py
@@ -105,6 +105,10 @@ make_package_schema = Schema({
     # package names, possibly including meta-packages (like 'sh') that
     # don't really exist but are provided by bash.
     Required("build_provides"): list,
+    # What packages are depended on by this build? This will be a list of
+    # package names, possibly including meta-packages (like 'sh') that
+    # don't really exist but are provided by bash.
+    Required("build_depends"): list,
     Required("log"): [
         # Logs have a head and body. Typically, for each command that
         # gets executed by the make_package stage, the head will be the
@@ -136,6 +140,7 @@ post_processed_schema = Schema({
     Required("time"): All(int, Range(min=0)),
     Required("toolchain"): _nonempty_string,
     Required("build_provides"): list,
+    Required("build_depends"): list,
     Required("errors"): list,
     # Status of all configure checks in this build, combined.
     # If a single configure check returned non-zero, then False;

--- a/tuscan/utilities.py
+++ b/tuscan/utilities.py
@@ -116,7 +116,7 @@ def timestamp():
 
 
 def log(kind, string, output=[], start_time=None):
-    if kind not in ["command", "info", "die", "provide_info"]:
+    if kind not in ["command", "info", "die", "provide_info", "dep_info"]:
         raise RuntimeError("Bad kind: %s" % kind)
 
     if not start_time:


### PR DESCRIPTION
Each build now logs the packages that it depends on before beginning.
This will allow us to build a graph of what failing packages are
blocking other packages from building, and determining what packages are
the biggest blockers etc.
