### PR TITLE
Missing source is detected earlier in build

### DIFF
--- a/tuscan/classification_patterns.yaml
+++ b/tuscan/classification_patterns.yaml
@@ -32,6 +32,10 @@
   category: "missing_header"
   severity: error
 - 
+  pattern: "No source directory in source volume: (?P<dir>.+)"
+  category: "missing_source"
+  severity: error
+- 
   pattern: "==> ERROR: Failure while downloading"
   category: "missing_source"
   severity: error


### PR DESCRIPTION
This commit adds a check for source directories that don't exist on the
permanent source volume at all (as opposed to source that can't be
obtained for some other reason). It is an earlier check for missing
source than the checks we already had, and fails the build with a log
message rather than causing a crash.
