### PR TITLE
All output files rooted at single output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,17 @@ Post-processing the data from a build:
 
     ./tuscan.py post
 
-The resulting JSON files are dumped in the `post/TOOLCHAIN` directory,
-one file per package. The schema for the resulting JSON file is
-described by the `post_processed_schema` structure in
+The resulting JSON files are dumped in the `output/post/TOOLCHAIN`
+directory, one file per package. The schema for the resulting JSON file
+is described by the `post_processed_schema` structure in
 `tuscan/schemata.py`.
 
 Generating a HTML report from post-processed data:
 
     ./tuscan.py html
 
-The resulting HTML pages are dumped in the `html/TOOLCHAIN` directory,
-one page per package.
+The resulting HTML pages are dumped in the `output/html/TOOLCHAIN`
+directory, one page per package.
 
 
 Structure / Contributing

--- a/tuscan/tuscan_build.py
+++ b/tuscan/tuscan_build.py
@@ -513,7 +513,7 @@ def do_build(args):
         args.run = True
 
     timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
-    args.touch_dir = join("results", args.toolchain, timestamp, "")
+    args.touch_dir = join("output/results", args.toolchain, timestamp, "")
 
     ninja_file = "tuscan.ninja"
     with open(ninja_file, "w") as f:

--- a/tuscan/tuscan_html.py
+++ b/tuscan/tuscan_html.py
@@ -85,8 +85,8 @@ def dump_build_page(json_path, toolchain, jinja, out_dir, args):
 
 
 def do_html(args):
-    src_dir = "post"
-    dst_dir = "html"
+    src_dir = "output/post"
+    dst_dir = "output/html"
 
     if not isdir(src_dir):
         stderr.write("directory 'post' does not exist; run './tuscan.py"
@@ -95,6 +95,8 @@ def do_html(args):
 
     jinja = Environment(loader=FileSystemLoader(["tuscan"]))
 
+    if not isdir(dst_dir):
+        makedirs(dst_dir)
     copyfile("tuscan/style.css", join(dst_dir, "style.css"))
 
     for toolchain in listdir(src_dir):

--- a/tuscan/tuscan_postprocess.py
+++ b/tuscan/tuscan_postprocess.py
@@ -139,9 +139,10 @@ def do_postprocess(args):
                      (str(e), str(patterns)))
         exit(1)
 
-    dst_dir = "post"
-    src_dir = "results"
+    dst_dir = "output/post"
+    src_dir = "output/results"
     pool = Pool(args.pool_size)
+
     for toolchain in listdir(src_dir):
         toolchain_dst = join(dst_dir, toolchain)
 


### PR DESCRIPTION
The following three directories, which were created at the top level,
will now be created in a single top-level directory called output:
- results:  the JSON results of running the experiment
- post:     the post-processed JSON results
- html:     HTML reports generated from post-processed results

This is so that these directories can be stored on a separate high-
performance filesystem with write barriers and journaling disabled,
mounted on the output directory, for increased system responsiveness and
reduced disk wear.
