### PR TITLE
HTML display of blockers

### DIFF
--- a/tuscan/build.jinja.html
+++ b/tuscan/build.jinja.html
@@ -34,6 +34,33 @@
     {% if data["return_code"] is equalto 0 %}SUCCESSFUL.
     {% else %}NOT successful.{% endif %}
     </p>
+    {% if data["blocks"] %}
+    <p>
+    This build failed despite all of its dependencies building
+    successfully. It is blocking the following {{ data["block_number"] }}
+    packages from building:
+    </p>
+    <ul>
+      {% for blocked in data["blocks"] %}
+      <li>
+        <a href="{{ blocked }}.html">{{ blocked }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    {% if data["blocked_by"] %}
+    <p>
+    This build was not attempted because the following
+    {{ data["block_number"] }} of its dependencies failed to build:
+    </p>
+    <ul>
+      {% for blocker in data["blocked_by"] %}
+      <li>
+        <a href="{{ blocker }}.html">{{ blocker }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
     {% if data["errors"] %}
     <h2>List of Errors</h2>
     <ul>

--- a/tuscan/package_list.html.jinja
+++ b/tuscan/package_list.html.jinja
@@ -24,21 +24,24 @@
       Build Name
     <th>
   </tr>
-  {% for build_name, obj in builds.iteritems() %}<tr>
+  {% for build_name in order %}<tr>
     {% for tc in toolchains %}
-      {% if obj[tc] %}
-        {% if obj[tc]["return_code"] %}
-        <td class="no-build-cell">
-          <a href="../{{ tc }}/{{ build_name }}.html">y</a>
-        </td>
+      {% if build_name in builds %}
+        {% if builds[build_name][tc] %}
+          {% if builds[build_name][tc]["return_code"] %}
+          <td class="no-build-cell">
+            <a href="../{{ tc }}/{{ build_name }}.html">y</a>
+          </td>
+          {% else %}
+          <td class="build-cell">
+            <a href="../{{ tc }}/{{ build_name }}.html">y</a>
+          </td>
+          {% endif %}
         {% else %}
-        <td class="build-cell">
-          <a href="../{{ tc }}/{{ build_name }}.html">y</a>
-        </td>
+          <td class="unknown-cell">
+            .
+          </td>
         {% endif %}
-      {% else %}
-        <td class="unknown-cell">
-        </td>
       {% endif %}
     {% endfor %}
     <td>{{ build_name }}</td>


### PR DESCRIPTION
HTML reports now display blocker information in two ways:
- A summary page of all blockers for each toolchain is generated. The
  page is sorted, with builds that block the highest number of packages
  shown at the top.
- On individual build pages of blocked packages, the packages that are
  blocking this package from being build is displayed. On individual
  build pages of blocker packages, the packages that they are blocking
  is displayed.
