### PR TITLE
SLOC information dumped during build

### DIFF
--- a/package_build_wrapper.py
+++ b/package_build_wrapper.py
@@ -116,6 +116,12 @@ def run_container(args):
                 # of the dependencies have also failed.
                 json_result["build_depends"] = obj["body"]
 
+            elif obj["kind"] == "sloc_info":
+                # This will be a dictionary (encoded as a JSON string)
+                # mapping languages to lines-of-code, as reported by
+                # SLOCCount.
+                json_result["sloc_info"] = loads(obj["body"])
+
             else:
                 json_result["log"].append(obj)
 
@@ -132,6 +138,9 @@ def run_container(args):
     json_result["toolchain"] = args.toolchain
     json_result["errors"] = errors
     json_result["bootstrap"] = False
+
+    if not "sloc_info" in json_result:
+        json_result["sloc_info"] = {}
 
     for touch_file in args.output_packages:
         with open(touch_file, "w") as f:

--- a/stages/install_bootstrap/main.py
+++ b/stages/install_bootstrap/main.py
@@ -59,7 +59,8 @@ def main():
         name_data = load(f)
     bootstrap_packs = (name_data["base"]
                       + name_data["base_devel"]
-                      + name_data["tools"])
+                      + name_data["tools"]
+                      + ["sloccount"])
 
     vanilla = "file://" + args.mirror_directory + "/$repo/os/$arch"
     log("info", "Printing %s to mirrorlist" % vanilla)

--- a/tuscan/schemata.py
+++ b/tuscan/schemata.py
@@ -109,6 +109,11 @@ make_package_schema = Schema({
     # package names, possibly including meta-packages (like 'sh') that
     # don't really exist but are provided by bash.
     Required("build_depends"): list,
+    # Map from languages in this build, to how many LOC are written in
+    # that language.
+    Required("sloc_info"): Schema({
+        _nonempty_string: int
+    }),
     Required("log"): [
         # Logs have a head and body. Typically, for each command that
         # gets executed by the make_package stage, the head will be the
@@ -153,6 +158,7 @@ post_processed_schema = Schema({
     # is said to block C. Note that if a package is a blocker, but it
     # has no dependencies, then it's "blocks" list will be empty.
     Required("blocked_by"): [_nonempty_string],
+    Required("sloc_info"): Schema({ _nonempty_string: int }),
     Required("errors"): list,
     # Status of all configure checks in this build, combined.
     # If a single configure check returned non-zero, then False;

--- a/tuscan/utilities.py
+++ b/tuscan/utilities.py
@@ -116,7 +116,8 @@ def timestamp():
 
 
 def log(kind, string, output=[], start_time=None):
-    if kind not in ["command", "info", "die", "provide_info", "dep_info"]:
+    if kind not in ["command", "info", "die", "provide_info",
+            "dep_info", "sloc_info"]:
         raise RuntimeError("Bad kind: %s" % kind)
 
     if not start_time:


### PR DESCRIPTION
The make_package stage now dumps lines-of-code information into the
result data structure for a build. The result data structure now
includes a dictionary mapping languages to lines of code written in that
language for that build.
