### PR TITLE
SLOC distribution figure

### DIFF
--- a/tuscan/plots/sloc-distribution.gnu
+++ b/tuscan/plots/sloc-distribution.gnu
@@ -1,0 +1,20 @@
+set boxwidth 0.8 relative
+set style fill solid 1.0
+
+set terminal eps
+set output 'output/figures/{{ name }}.eps'
+
+unset key
+
+unset border
+set xtics nomirror
+set ytics nomirror
+set border 3
+
+set xlabel "LOC"
+set ylabel "# Programs with LOC"
+set title "Distribution of program sizes"
+
+plot '-' using 2:xticlabels(1) with boxes lt -1
+{{ data }}
+EOF


### PR DESCRIPTION
The `tuscan figures` command now generates a plot showing the
distribution of sizes of programs that have been built. For each order
of magnitude of lines of code (10 LOC, 100 LOC, ...) the graph shows how
many programs are at most that large.
![image](https://cloud.githubusercontent.com/assets/2887605/15663334/d11c4888-26f1-11e6-81da-944ee56dac64.png)
