### PR TITLE
HTML sidebar filters out non-C(++) builds

### DIFF
--- a/tuscan/tuscan_html.py
+++ b/tuscan/tuscan_html.py
@@ -99,8 +99,17 @@ def summary_structure(toolchains):
           "name": "all",
           "description": "all builds across all toolchains",
           "link_text": "{total} total builds"
+          }, {
+            "name": "cish-programs",
+            "filter": (lambda build: (
+                "ansic" in build["sloc_info"] or
+                "cpp" in build["sloc_info"]
+            )),
+            "description": "Builds that contain C/C++ code",
+            "link_text": "{total} of these contain C(++) code.",
+            "children": toolchain_trees
           }
-      ] + toolchain_trees)
+      ])
     }
 
     return top_level_tree


### PR DESCRIPTION
The HTML report now excludes builds that do not contain any C or C++
code at all but the top-level.
