### PR TITLE
HTML display of native tool invocations

### DIFF
--- a/tuscan/build.jinja.html
+++ b/tuscan/build.jinja.html
@@ -33,6 +33,18 @@
     <p>The build took {{ data["time"]}} and was
     {% if data["return_code"] is equalto 0 %}SUCCESSFUL.
     {% else %}NOT successful.{% endif %}
+    {% if data["native_tools"] %}
+    <p>This build attempted to bypass our toolchain by invoking native
+    tools; we intercepted these invocations and sent them to our
+    toolchain. The frequency of each native tool invocation is given
+    here:</p>
+    <table>
+      <tr><th>tool</th><th>frequency</th></tr>
+      {% for tool, freq in data["native_tools"].items() %}
+      <tr><td><code>{{ tool }}</code></td><td>{{ freq }}</td></tr>
+      {% endfor %}
+    </table>
+    {% endif %}
     </p>
     {% if data["errors"] %}
     <h2>List of Errors</h2>

--- a/tuscan/tuscan_html.py
+++ b/tuscan/tuscan_html.py
@@ -51,6 +51,12 @@ def summary_structure(toolchains):
         _patterns = load_yaml(f)
     categories = set([p["category"] for p in _patterns])
 
+    def native_tool_freq(build):
+        total = 0
+        for _, freq in build["native_tools"].items():
+            total += freq
+        return -1 * total
+
     def error_trees(toolchain):
         error_trees = []
         for category in categories:
@@ -65,6 +71,15 @@ def summary_structure(toolchains):
                 "link_text": "%s ({total} builds)" % category
             }
             error_trees.append(obj)
+        error_trees.append({
+            "name": "native-redirect",
+            "filter": (lambda b: b["native_tools"]),
+            "description": ("Builds that failed even after their native"
+                            " tools were redirected to toolchain tools "
+                            "(sorted by number of invocations)"),
+            "link_text": "Builds invoking native tools ({total})",
+            "sort_fun": native_tool_freq
+        })
         return error_trees
 
     toolchain_trees = []
@@ -79,7 +94,18 @@ def summary_structure(toolchains):
                 "filter": (lambda build: build["return_code"] == 0),
                 "description": ("Builds that passed with toolchain "
                                 "'%s'" % toolchain),
-                "link_text": "{total} passed"
+                "link_text": "{total} passed",
+                "children": [{
+                    "name": "native-redirect",
+                    "filter": (lambda b: b["native_tools"]),
+                    "description": ("Builds that passed only after "
+                                    "their native tools were redirected"
+                                    " to toolchain tools (sorted by "
+                                    "number of invocations)"),
+                    "link_text": ("({total} had their native "
+                                  "tools redirected)"),
+                    "sort_fun": native_tool_freq
+                }]
               }, {
                 "name": "fail",
                 "filter": (lambda build: build["return_code"] != 0),


### PR DESCRIPTION
HTML reports of individual builds now display how many native tools were
invoked.

HTML summary pages now include the number of builds that invoked native
tools---both those that passed, and those that failed.
