### PR TITLE
More accurate build count on HTML summary pages

### DIFF
--- a/tuscan/tuscan_html.py
+++ b/tuscan/tuscan_html.py
@@ -169,7 +169,8 @@ def create_summary_pages(summary, ret, parent_name, builds, toolchains, jinja):
             "length": len(organised)
         })
 
-        link_text = summary["link_text"].format(total=len(new_builds))
+        link_text = summary["link_text"].format(
+                total=len(new_builds) / len(new_toolchains))
         list_text = ('<li>\n<a href="{name}.html">{link_text}</a>\n'
                      '\n{child_list}\n</li>').format(
                         name=name, link_text=link_text,


### PR DESCRIPTION
Summary pages can display the total number of builds on that page.
Previous to this commit, summary pages that displayed builds for more
than one toolchain would count each build once for each toolchain, i.e.
tripling the apparent number of builds if there are three toolchains on
display.

This commit changes that behaviour so that the "total" number of builds
is the number of builds divided by the number of toolchains on display.
