### PR TITLE
Improved memory efficiency of blocker post-process

### DIFF
--- a/tuscan.py
+++ b/tuscan.py
@@ -65,10 +65,6 @@ def main():
             help=("Kill post-processing if it takes longer than"
                   " N seconds (default=%d)" % 1200))
 
-    postprocess_parser.add_argument("-b", "--calculate-blockers",
-            action="store_true", help=("Calculate which builds are "
-                "blocking which others (recommended: > 80 GB RAM)"))
-
     postprocess_parser.set_defaults(func=do_postprocess)
 
     # ./tuscan.py html


### PR DESCRIPTION
Post-processed results are no longer stored in an inter-process data
structure while waiting to have their blockers calculated, as this was a
huge waste of memory. Instead, results are written to disk after all
post-processing except for blocker analysis is done. When all results
have been written, only the necessary data for blocker analysis is re-
loaded from disk; the on-disk results are then updated with the blocker
results.

Due to this improvement, the blocker analysis has been re-enabled by
default.
