### PR TITLE
HTML display of blockers

### DIFF
--- a/tuscan/build.jinja.html
+++ b/tuscan/build.jinja.html
@@ -34,6 +34,28 @@
     {% if data["return_code"] is equalto 0 %}SUCCESSFUL.
     {% else %}NOT successful.{% endif %}
     </p>
+    {% if data["blocked_by"] %}
+    <p>
+    We did not attempt to build this package because some of its
+    dependencies failed to build. These dependencies are:
+    </p>
+    <ul>
+      {% for d in data["blocked_by"] %}
+      <li><a href="{{ d }}.html">{{ d }}</a></li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    {% if data["blocks"] %}
+    <p>
+    Due to the failure of this package to build, we did not attempt to
+    build several packages that depend on this one. Those packages are:
+    </p>
+    <ul>
+      {% for d in data["blocks"] %}
+      <li><a href="{{ d }}.html">{{ d }}</a></li>
+      {% endfor %}
+    </ul>
+    {% endif %}
     {% if data["errors"] %}
     <h2>List of Errors</h2>
     <ul>

--- a/tuscan/tuscan_html.py
+++ b/tuscan/tuscan_html.py
@@ -65,6 +65,16 @@ def summary_structure(toolchains):
                 "link_text": "%s ({total} builds)" % category
             }
             error_trees.append(obj)
+        error_trees.append({
+            "name": "blockers",
+            "filter": (lambda build, toolchain=toolchain:
+                build["return_code"] and build["toolchain"] == toolchain
+                and not "missing_deps" in build["category_counts"]),
+            "description": ("Packages whose dependencies all built, "
+                            "but which failed to build on toolchain"
+                            " '%s'" % toolchain),
+            "link_text": "Blockers ({total} builds)"
+        })
         return error_trees
 
     toolchain_trees = []
@@ -247,6 +257,8 @@ def dump_build_page(json_path, toolchain, jinja, out_dir, args,
         data["name"] = basename(data["build_name"])
         data["time"] = s_to_hhmmss(data["time"])
         data["errors"] = get_errors(data["log"])
+        data["blocks"] = [basename(b) for b in data["blocks"]]
+        data["blocked_by"] = [basename(b) for b in data["blocked_by"]]
         html = template.render(data=data)
 
         out_path = join(out_dir, "%s.html" % basename(data["build_name"]))


### PR DESCRIPTION
Blockers for each toolchain are displayed in the summary sidebar.
Packages which block others from building, and packages that have been
blocked from building, now contain a message on their individual pages.
