### PR TITLE
Bear is called on each build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bear"]
+	path = bear
+	url = https://github.com/karkhaz/Bear.git

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ programs in various compilation environments:
 Initial setup
 -------------
 
+Tuscan uses a [fork](https://github.com/karkhaz/Bear) of the
+[libEAR](https://github.com/rizsotto/Bear) project as a submodule. You
+will thus need to pass the `--recursive` switch to the `git clone`
+command when cloning Tuscan, or else run `git submodule init; git
+submodule update` after you have cloned it.
+
 Tuscan uses a mirror of Arch Linux binaries and sources.
 
 ### Binaries

--- a/package_build_wrapper.py
+++ b/package_build_wrapper.py
@@ -122,6 +122,10 @@ def run_container(args):
                 # SLOCCount.
                 json_result["sloc_info"] = loads(obj["body"])
 
+            elif obj["kind"] == "bear":
+                # This will be an "exec" or "exit" record from libEAR.
+                json_result["bear_output"] = obj["body"]
+
             else:
                 json_result["log"].append(obj)
 
@@ -141,6 +145,9 @@ def run_container(args):
 
     if not "sloc_info" in json_result:
         json_result["sloc_info"] = {}
+
+    if not "bear_output" in json_result:
+        json_result["bear_output"] = []
 
     for touch_file in args.output_packages:
         with open(touch_file, "w") as f:

--- a/stages/install_bootstrap/deps.yaml
+++ b/stages/install_bootstrap/deps.yaml
@@ -13,6 +13,7 @@ run:
       - toolchain_${TOOLCHAIN}_repo
     local_mounts:
       - mirror
+      - bear
 
   # make_package containers are based on the image of this stage,
   # therefore don't delete the container when finished and do a docker

--- a/tuscan/schemata.py
+++ b/tuscan/schemata.py
@@ -114,6 +114,24 @@ make_package_schema = Schema({
     Required("sloc_info"): Schema({
         _nonempty_string: int
     }),
+    # Output from the bear tool wrapping the makepkg command.
+    Required("bear_output"): Schema([ Any(
+        Schema({
+            "kind": "exit",
+            "pid": _nonempty_string,
+            "ppid": _nonempty_string,
+            "return_code": _nonempty_string
+        }),
+        Schema({
+            "kind": "exec",
+            "timestamp": _nonempty_string,
+            "pid": _nonempty_string,
+            "ppid": _nonempty_string,
+            "directory": _nonempty_string,
+            "function": _nonempty_string,
+            "command": [ _string ]
+        })
+    )]),
     Required("log"): [
         # Logs have a head and body. Typically, for each command that
         # gets executed by the make_package stage, the head will be the
@@ -159,6 +177,23 @@ post_processed_schema = Schema({
     # has no dependencies, then it's "blocks" list will be empty.
     Required("blocked_by"): [_nonempty_string],
     Required("sloc_info"): Schema({ _nonempty_string: int }),
+    Required("bear_output"): Schema([ Any(
+        Schema({
+            "kind": "exit",
+            "pid": _nonempty_string,
+            "ppid": _nonempty_string,
+            "return_code": _nonempty_string
+        }),
+        Schema({
+            "kind": "exec",
+            "timestamp": _nonempty_string,
+            "pid": _nonempty_string,
+            "ppid": _nonempty_string,
+            "directory": _nonempty_string,
+            "function": _nonempty_string,
+            "command": [ _string ]
+        })
+    )]),
     Required("errors"): list,
     # Status of all configure checks in this build, combined.
     # If a single configure check returned non-zero, then False;

--- a/tuscan/tuscan_build.py
+++ b/tuscan/tuscan_build.py
@@ -319,7 +319,7 @@ class Stages(object):
                     main_command += " "
 
                 for mount in stage.run.local_mounts:
-                    main_command += ("-v %s/%s:/%s:ro" %
+                    main_command += (" -v %s/%s:/%s:ro" %
                                      (getcwd(), mount, mount))
 
                 main_command += (" --name %s %s --output-directory %s"

--- a/tuscan/tuscan_html.py
+++ b/tuscan/tuscan_html.py
@@ -310,6 +310,7 @@ def dump_build_page(json_path, toolchain, jinja, out_dir, args,
         # keep the build log for the summary, and it uses a lot of
         # memory, so remove it from the data structure.
         data.pop("log", None)
+        data.pop("bear_output", None)
         results_list.append(data)
 
     except MultipleInvalid as e:


### PR DESCRIPTION
The bear tool, which has been added as a submodule of this project, is
used to wrap each invocation of makepkg. The output is stored as part of
the JSON result structure.
