### PR TITLE
Sources/binaries/base container created atomically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ tuscan.ninja
 .ninja_log
 
 mirror
-
+sources
 output

--- a/README.md
+++ b/README.md
@@ -19,36 +19,38 @@ will thus need to pass the `--recursive` switch to the `git clone`
 command when cloning Tuscan, or else run `git submodule init; git
 submodule update` after you have cloned it.
 
-Tuscan uses a mirror of Arch Linux binaries and sources.
+On the first run, Tuscan will attempt to download a copy of every
+official Arch Linux binary package, as well as their corresponding
+sources. These files are placed in the `mirror` and `sources` directory,
+respectively. During the first run, Tuscan will also create and commit
+an Arch Linux Docker image called `tuscan_base_image`, whose software
+databases are in sync with the downloaded sources and binaries.  _Do not
+remove this image_ from your system; if you do, you will need to
+re-create it and also re-download up-to-date versions of the sources and
+binaries.
 
-### Binaries
+Occasionally, downloads of a source or binary may fail; when this
+happens for a particular package, a `$PACKAGE_NAME.log` file will be
+left in the `sources` or `mirror` directory, containing information on
+the failure.
 
-Tuscan expects that a mirror Arch Linux binaries exists in the top-level
-directory, named `mirror`. If you obtain a copy of Arch Linux binaries
-from your local mirror, you may wish to remove i386 binaries to save
-space.
+- For binaries, you may wish to download the binary yourself and place
+  it in the `mirror` directory. An archive of all Arch Linux binaries is
+  hosted at the [Arch Archive](https://archive.archlinux.org/packages/);
+  make sure that the version number that you're downloading matches the
+  version described in the `.log` file.
 
-### Sources
+- A failed download of a source file usually indicates that the upstream
+  source is broken. It may be appropriate to file a bug about this on
+  the [Arch Linux bug tracker](https://bugs.archlinux.org/). There is
+  not much that can be done about this; Tuscan will fail to build that
+  package and any packages that depend on it.
 
-By default, Tuscan downloads sources of Arch Linux packages into a data
-container called `sources` as it runs, so you don't need to provide
-this.
-
-If you have atomically downloaded a copy of all Arch sources and wish to
-add it to Tuscan, you will need to add it to the sources data container.
-
-1. Create the data container if it doesn't already exist:
-
-        docker create -v /sources --name sources base/arch /bin/true
-
-1. Spin up a docker container that mounts the data container as well as
-   the local sources directory, and copies the contents of the sources
-   directory into the container:
-
-        docker run --volumes-from sources -v \
-          $(pwd)/tmp_sources:/tmp_sources base/arch \
-          sh -c 'cp /tmp_sources/* /sources'
-
+Binaries are downloaded from an Arch Linux mirror. If you don't live in
+the United States, you may wish to replace "United States" in the
+`stages/create_base_image/main.sh` script. The invocation of `reflector`
+in that script finds the fastest and most up-to-date Arch mirrors from
+the specified country.
 
 
 Running Tuscan
@@ -110,9 +112,20 @@ described in the file `stages/$STAGE_NAME/deps.yaml`.
 Dependencies
 ------------
 
+Software:
+
 *   docker
 
     (you should add your user to the 'docker' group)
+
+*   gnuplot
+
+    http://gnuplot.info
+
+Tuscan also requires several Python packages. These can be installed
+with `pip`. Tuscan code that runs on your host machine is written in
+Python 2, so if your operating system uses Python 3 by default you may
+need to install these packages with `pip2`.
 
 *   ninja
 
@@ -122,14 +135,13 @@ Dependencies
 
     http://pyyaml.org/
 
-
 *   Jinja2
 
     http://jinja.pocoo.org/docs/dev/
 
-*   gnuplot
+*   docker-py
 
-    http://gnuplot.info
+    https://github.com/docker/docker-py
 
 
 Troubleshooting

--- a/data_containers.yaml
+++ b/data_containers.yaml
@@ -8,12 +8,6 @@
   mountpoint: /tuscan_data
   switch: shared
 
-# Source packages are located under this directory.
-- 
-  name: sources
-  mountpoint: /sources
-  switch: sources
-
 # Local repository for toolchain-built packages.
 - 
   name: toolchain_${TOOLCHAIN}_repo

--- a/package_build_wrapper.py
+++ b/package_build_wrapper.py
@@ -33,9 +33,6 @@ def get_parser():
     parser.add_argument("--shared-directory", required=True)
     parser.add_argument("--shared-volume", required=True)
 
-    parser.add_argument("--sources-directory", required=True)
-    parser.add_argument("--sources-volume", required=True)
-
     parser.add_argument("--toolchain-directory", required=True)
     parser.add_argument("--toolchain-volume", required=True)
 
@@ -57,15 +54,14 @@ def run_container(args):
                " --rm"
                " -v {shared_directory}"
                " --volumes-from {shared_volume}"
-               " -v {sources_directory}"
-               " --volumes-from {sources_volume}"
                " -v {toolchain_directory}"
                " --volumes-from {toolchain_volume}"
                " -v {cwd}/mirror:/mirror:ro"
+               " -v {cwd}/sources:/sources:ro"
                " make_package"
 
                # Arguments to the make_package stage inside container:
-               " --sources-directory {sources_directory}"
+               " --sources-directory /sources"
                " --shared-directory {shared_directory}"
                " --toolchain-directory {toolchain_directory}"
                " --abs-dir {abs_dir}"
@@ -73,8 +69,6 @@ def run_container(args):
 
                ).format(shared_directory=args.shared_directory,
                         shared_volume=args.shared_volume,
-                        sources_directory=args.sources_directory,
-                        sources_volume=args.sources_volume,
                         toolchain_directory=args.toolchain_directory,
                         toolchain_volume=args.toolchain_volume,
                         abs_dir=args.abs_dir,
@@ -169,9 +163,6 @@ def main():
 
     parser.add_argument("--shared-directory", required=True)
     parser.add_argument("--shared-volume", required=True)
-
-    parser.add_argument("--sources-directory", required=True)
-    parser.add_argument("--sources-volume", required=True)
 
     parser.add_argument("--toolchain-directory", required=True)
     parser.add_argument("--toolchain-volume", required=True)

--- a/stages/create_base_image/Dockerfile
+++ b/stages/create_base_image/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All Rights Reserved.
+# Copyright 2016 Kareem Khazem. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,17 +12,12 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Arch Linux container for building all dependencies of all Arch Linux
-# packages.
-#
-# USAGE:
-#   docker run container_name
 
-FROM tuscan_base_image:latest
-MAINTAINER Kareem Khazem <khazem@google.com>
+FROM rafaelsoares/archlinux
+MAINTAINER Kareem Khazem <karkhaz@karkhaz.com>
 
-COPY main.py /build/main.py
 COPY utilities.py /build/utilities.py
+COPY getpkgs.py /build/getpkgs.py
+COPY main.sh /build/main.sh
 
-ENTRYPOINT ["/usr/bin/python", "-u", "/build/main.py"]
+ENTRYPOINT ["/usr/bin/bash", "/build/main.sh"]

--- a/stages/create_base_image/deps.yaml
+++ b/stages/create_base_image/deps.yaml
@@ -1,0 +1,16 @@
+---
+build:
+  copy_files:
+    - stages/create_base_image/main.sh
+    - stages/create_base_image/getpkgs.py
+    - tuscan/utilities.py
+
+run:
+  dependencies:
+    data_containers:
+      - tuscan_data
+    local_mounts:
+      - mirror
+      - sources
+  rm_container: false
+  post_exit: docker commit create_base_image tuscan_base_image

--- a/stages/create_base_image/getpkgs.py
+++ b/stages/create_base_image/getpkgs.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+#
+# Copyright 2016 Kareem Khazem. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Download all Arch sources & binaries and create Tuscan base image
+
+This stage does three things:
+
+- Downloads binaries of all official Arch Linux packages in the core,
+  extra and community repositories, and writes them into a directory
+  mounted from the host system.
+
+- Downloads sources corresponding to those binaries, and writes them
+  into a different directory mounted from the host system
+
+- Creates a Docker image where the software database is in sync with the
+  downloaded sources and binaries. The image is committed, and all other
+  Tuscan stages shall be based on that image.
+
+This means that once this stage has successfully run, other stages
+should not need to access the network (unless a particular package needs
+to do so as part of its build process; this does happen occasionally).
+All package transactions shall happen relative to the local binary and
+source mirrors, rather than querying remote mirrors.
+
+This script is executed _after_ stages/create_base_image/main.sh, which
+installs the basic environment (including Python).
+"""
+
+
+from utilities import timestamp, recursive_chown
+from utilities import set_local_repository_location
+
+import requests
+
+import argparse
+import codecs
+import concurrent.futures
+import functools
+import json
+import logging
+import multiprocessing
+import os
+import os.path
+import random
+import re
+import signal
+import shutil
+import subprocess
+import sys
+import time
+
+
+def get_package_info(pkg_name):
+    cmd = "pacman -Si %s" % pkg_name
+    proc = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+    out, _ = proc.communicate()
+    if proc.returncode:
+        report_failure("sources", "Unable to find package data.", pkg_name)
+        return None
+    output = codecs.decode(out, errors="replace")
+    for line in output.splitlines():
+        m = re.match("Version\s+:\s+(?P<ver>.+)", line)
+        if m:
+            version = m.group("ver")
+        m = re.match("Architecture\s+:\s+(?P<arch>.+)", line)
+        if m:
+            arch = m.group("arch")
+        m = re.match("Repository\s+:\s+(?P<repo>.+)", line)
+        if m:
+            repo = m.group("repo")
+    if not version or not repo or not arch:
+        report_failure("sources", ("Unable to obtain information "
+                                   "for package '{pack}'\n"
+                                   "Version: {ver}\n"
+                                   "Repo: {repo}\n"
+                                   "Arch: {arch}").format(
+                                       ver=version, arch=arch,
+                                       repo=repo, pack=pkg_name),
+                                   pkg_name)
+        return None
+    return {
+        "version": version,
+        "arch": arch,
+        "repo": repo
+    }
+
+
+def report_failure(kind, message, package_name):
+    if kind not in ["mirror", "sources"]:
+        raise ValueError("Bad kind '%s'" % kind)
+    log_name = os.path.join("/%s" % kind, "%s.log" % package_name)
+    with open(log_name, "w") as f:
+        f.write("%s\n" % message)
+    logging.error("Failed to download %s into %s" % (package_name, kind))
+
+
+def download_source(path):
+    """Download sources for the package whose abs dir is path.
+
+    If sources are not downloaded for some reason, a file called
+    /sources/$PKGNAME.log will contain more information about the
+    reason.
+    """
+
+    abs_name = os.path.basename(path)
+
+    source_dir = os.path.join("/sources", abs_name)
+    shutil.copytree(path, source_dir)
+    recursive_chown(source_dir)
+
+    # makepkg must be run in the directory where the PKGBUILD is.
+    # However, we cannot use os.chdir because the cwd is process-wide,
+    # not thread-local, and we're using threading rather than
+    # multiprocessing.  Therefore, pass a new cwd to the subprocess.
+    #
+    # We want to download and extract the source, but not build it.
+    # PKGBUILDs also have a prepare() function that gets executed
+    # after extraction but before building; we shouldn't run that
+    # function either, since it might need some of the packages in
+    # `makedepends` to be installed. We should avoid installing those,
+    # since we would need to lock otherwise (only one Pacman can be
+    # running at a time).
+    #
+    # We don't pass --syncdeps (so that dependencies don't get
+    # installed) and also pass --nodeps (so that makepkg doesn't error
+    # out when it notices that not all dependencies are installed),
+    # because we're not building anything. Anything that is required for
+    # downloading and source extraction should already be installed by
+    # the create_base_image/main.sh script.
+    #
+    # GPG and SHA take forever, and there's a serious risk that we fill
+    # up the container's process table with unreaped children if we do
+    # integrity checks; so don't bother.
+    cmd = ("sudo -u tuscan makepkg --noprepare --nobuild --nocheck"
+           " --nodeps --noarchive --skipinteg --nocolor --nosign")
+    proc = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT, cwd=source_dir)
+    try:
+        out, _ = proc.communicate(timeout=1800)
+    except subprocess.TimeoutExpired:
+        report_failure("sources", "timed out", abs_name)
+        return
+    output = codecs.decode(out, errors="replace")
+    if proc.returncode:
+        shutil.rmtree(source_dir)
+        report_failure("sources", output, abs_name)
+
+
+def download_binary(pkg_name, session, servers):
+    """Download binary package.
+
+    If the binary is not downloaded for some reason, a file called
+    /mirror/$PKGNAME.log will contain more information about the
+    reason.
+    """
+
+    servers = list(servers)
+    random.shuffle(servers)
+    servers = servers[:DOWNLOAD_ATTEMPTS-1]
+
+    success = False
+    errors = []
+    for counter in range(DOWNLOAD_ATTEMPTS):
+        server = servers[counter]
+        info = get_package_info(pkg_name)
+        url = ("{server}/{repo}/os/x86_64/{pkg_name}-{ver}-{arch}"
+               ".pkg.tar.xz").format(server=server, repo=info["repo"],
+                       ver=info["version"], pkg_name=pkg_name,
+                       arch=info["arch"])
+        try:
+            response = session.get(url, timeout=30)
+        except requests.exceptions.Timeout:
+            errors.append("timed out")
+        except Exception as e:
+            errors.append(str(e))
+        else:
+            if response.status_code == requests.codes.ok:
+                success = True
+                f_name = "{name}-{ver}.pkg.tar.xz".format(
+                        name=pkg_name, ver=info["version"])
+                with open(os.path.join("/mirror", f_name), "wb") as f:
+                    f.write(response.content)
+                break
+            else:
+                errors.append(("Bad response %d for url '%s'.\nHeader:\n%s") %
+                              (response.status_code, url,
+                               str(response.headers)))
+    if success:
+        return
+    else:
+        error_str = "\nDownload attempt:\n".join(errors)
+        report_failure("mirror", error_str, pkg_name)
+
+
+def main():
+    paths = []
+    logging.basicConfig(format="%(asctime)s %(message)s",
+            level=logging.INFO)
+    jobs = multiprocessing.cpu_count()
+    random.seed()
+
+    # List of all source directories in the ABS.
+    for repo in ["core", "extra", "community"]:
+        dirs = os.listdir(os.path.join("/var/abs", repo))
+        paths += [os.path.join("/var/abs", repo, d) for d in dirs]
+
+    # The list of all binaries will be a superset of the list of source
+    # directories. This is because one source directory may create
+    # multiple binary packages.
+    packages = []
+    cmd = "pacman -Sl community core extra"
+    cp = subprocess.run(cmd.split(), stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT, universal_newlines=True)
+    if cp.returncode:
+        logging.error(cmd)
+        logging.error(cp.stdout)
+        exit(1)
+    for line in cp.stdout.splitlines():
+        m = re.match("\w+\s+(?P<pkg>[-\.@\+\w]+)\s+", line)
+        if m:
+            packages.append(m.group("pkg"))
+        else:
+            logging.error("Package '%s' does not match regex" % line)
+            exit(1)
+
+    servers = []
+    with open("/etc/pacman.d/mirrorlist") as f:
+        for line in f:
+            m = re.match("Server\s+=\s+(?P<url>http.+)\$repo/os/\$arch",
+                    line)
+            if m:
+                servers.append(m.group("url"))
+    if not servers:
+        with open("/etc/pacman.d/mirrorlist") as f:
+            mirrorlist = f.read()
+        logging.error("Could not find remote mirror")
+        logging.error("Contents of mirrorlist:\n%s" % mirrorlist)
+        exit(1)
+    else:
+        logging.info("Using servers: '%s'" % "\n".join(servers))
+
+    # We don't want to open a new connection to the mirror every time we
+    # want to download from it; this is impolite and the mirror will
+    # block us. We need a few more connections than concurrent worker,
+    # since when a worker makes a network request another worker will be
+    # permitted to execute. Therefore, use a requests.session object.
+    #
+    # We can't use a session object for downloading source, since that
+    # is not under our control (makepkg does the download). But source
+    # code comes from many different upstreams, so the load on each of
+    # them should be somewhat reduced.
+    session = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(pool_connections=jobs*2,
+            pool_maxsize=jobs*2)
+    # We only scraped the mirrorlist for HTTP mirrors, not rsync or HTTPS.
+    session.mount("http://", adapter)
+
+    download_binary_curry = functools.partial(download_binary,
+            session=session, servers=servers)
+
+    jobs_map = {}
+    for path in paths:
+        jobs_map[path] = download_source
+    for pack in packages:
+        jobs_map[pack] = download_binary_curry
+
+    original = signal.signal(signal.SIGINT, signal.SIG_IGN)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+        for item, fun in jobs_map.items():
+            pool.submit(fun, item)
+        signal.signal(signal.SIGINT, original)
+
+    # Now that we've downloaded all the binaries, we should add them to
+    # a local repository. This is because the install_bootstrap stage
+    # will later need to install packages. We can't use pacman -U in the
+    # install_bootstrap stage, since install_bootstrap does not only
+    # install bootstrap packages but also their dependencies. It would
+    # therefore install bootstrap packages from the local mirror and
+    # dependencies remotely if we passed -U...so create a local
+    # repository and install with -S instead.
+
+    local_repo = "/mirror/mirror.db.tar"
+
+    for pack in os.listdir("/mirror"):
+        pack = os.path.join("/mirror", pack)
+        cmd = "repo-add %s %s" % (local_repo, pack)
+        cp = subprocess.run(cmd.split(), stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT, universal_newlines=True)
+        if cp.returncode:
+            logging.error(cmd)
+            logging.error(cp.stdout.splitlines())
+            exit(1)
+
+    set_local_repository_location(os.path.dirname(local_repo),
+        os.path.splitext(os.path.splitext(os.path.basename(local_repo))[0])[0])
+
+
+# Try multiple different mirrors for each binary download
+DOWNLOAD_ATTEMPTS = 4
+
+if __name__ == "__main__":
+    main()

--- a/stages/create_base_image/main.sh
+++ b/stages/create_base_image/main.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Kareem Khazem. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -u
+set -x
+shopt -s failglob
+
+err() {
+  echo "ERROR: $*" >&2
+}
+
+pacman(){
+  /usr/bin/pacman --noprogressbar --noconfirm $*
+}
+
+if [ ! -d "/sources" ]; then
+  err "Sources directory not mounted"
+  exit 1
+fi
+
+if [ ! -d "/mirror" ]; then
+  err "Binaries directory not mounted"
+  exit 1
+fi
+
+# Ensure that the Pacman keyring is up-to-date
+pacman-key --init
+pacman-key --populate archlinux
+pacman-key --refresh-keys
+
+# These need to be up-to-date before doing anything else.
+pacman -Syy archlinux-keyring rsync reflector ca-certificates
+
+# Reflector finds and rates a list of Arch Linux mirrors by speed and
+# sync time, and saves it to the Pacman mirrorlist.
+reflector --sort rate --threads 2 --country "United States" \
+  --fastest 30 --age 24 --protocol http --save /etc/pacman.d/mirrorlist
+
+# Re-sync to fast mirrors gotten by Reflector and update software that
+# is already on the system
+pacman -Syyu
+
+# If Pacman itself was upgraded to a new major version, this might be
+# necessary; it's harmless otherwise
+pacman-db-upgrade
+
+# Download packages needed by all stages. We should also install
+# packages that are required for downloading and extracting source (git,
+# unzip etc).
+pacman -S base base-devel abs python python-requests parallel \
+  git mercurial openssh unzip svn darcs sudo python-jinja python-yaml \
+  binutils bison cmake ninja make libunistring patch wget
+
+# Synchronise ABS tree. We need to do this both to obtain sources, and
+# to know which binaries to download.
+abs core extra community
+
+# Avoid irritating progress bars from curl
+sed -ie 's/curl -fC/curl -sSfC/g' /etc/makepkg.conf
+
+# Since we're going to be running makepkg, we need a non-administrative
+# user. We need to be able to su into that user without being prompted.
+useradd -m -s /bin/bash tuscan
+echo "tuscan ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+echo "root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+chown tuscan: /mirror /sources
+
+# Onto downloading and building...
+python -u /build/getpkgs.py

--- a/stages/create_toolchain_repo/deps.yaml
+++ b/stages/create_toolchain_repo/deps.yaml
@@ -1,5 +1,7 @@
 ---
 build:
+  stages:
+    - create_base_image
   copy_files:
     - tuscan/utilities.py
 

--- a/stages/deps_to_ninja/Dockerfile
+++ b/stages/deps_to_ninja/Dockerfile
@@ -19,7 +19,7 @@
 # USAGE:
 #   docker run container_name
 
-FROM karkhaz/arch-tuscan:latest
+FROM tuscan_base_image:latest
 MAINTAINER Kareem Khazem <khazem@google.com>
 
 COPY main.py /build/main.py

--- a/stages/deps_to_ninja/deps.yaml
+++ b/stages/deps_to_ninja/deps.yaml
@@ -1,5 +1,7 @@
 ---
 build:
+  stages:
+    - create_base_image
   copy_files:
     - tuscan/ninja_syntax.py
     - tuscan/utilities.py
@@ -11,7 +13,6 @@ run:
       - get_base_package_names
     data_containers:
       - tuscan_data
-      - sources
       - toolchain_${TOOLCHAIN}_repo
 
   stdout: makepkg.ninja

--- a/stages/deps_to_ninja/main.py
+++ b/stages/deps_to_ninja/main.py
@@ -480,8 +480,6 @@ def main():
                ("container_build_dir/package_build_wrapper.py"
                " --shared-directory {shared_directory}"
                " --shared-volume {shared_volume}"
-               " --sources-directory {sources_directory}"
-               " --sources-volume {sources_volume}"
                " --toolchain-directory {toolchain_directory}"
                " --toolchain-volume {toolchain_volume}"
                " --toolchain {toolchain}"
@@ -493,8 +491,6 @@ def main():
                " ${{out}}"
     ).format(shared_directory=args.shared_directory,
              shared_volume=args.shared_volume,
-             sources_directory=args.sources_directory,
-             sources_volume=args.sources_volume,
              output_directory=args.output_directory,
              toolchain_directory=args.toolchain_directory,
              toolchain_volume=args.toolchain_volume,

--- a/stages/get_base_package_names/Dockerfile
+++ b/stages/get_base_package_names/Dockerfile
@@ -19,7 +19,7 @@
 # USAGE:
 #   docker run container_name
 
-FROM karkhaz/arch-tuscan:latest
+FROM tuscan_base_image:latest
 MAINTAINER Kareem Khazem <khazem@google.com>
 
 COPY main.py /build/main.py

--- a/stages/get_base_package_names/deps.yaml
+++ b/stages/get_base_package_names/deps.yaml
@@ -1,5 +1,7 @@
 ---
 build:
+  stages:
+    - create_base_image
   copy_files:
     - tuscan/utilities.py
 

--- a/stages/install_bootstrap/deps.yaml
+++ b/stages/install_bootstrap/deps.yaml
@@ -1,5 +1,7 @@
 ---
 build:
+  stages:
+    - create_base_image
   copy_files:
     - tuscan/utilities.py
     - tuscan/tool_wrapper.c

--- a/stages/make_package/deps.yaml
+++ b/stages/make_package/deps.yaml
@@ -15,7 +15,6 @@ run:
       - install_bootstrap
     data_containers:
       - tuscan_data
-      - sources
       - toolchain_${TOOLCHAIN}_repo
 
   command_override: ninja $VERBOSE -f makepkg.ninja

--- a/toolchains/install_bootstrap/android/Dockerfile
+++ b/toolchains/install_bootstrap/android/Dockerfile
@@ -19,7 +19,7 @@
 # USAGE:
 #   docker run container_name
 
-FROM karkhaz/arch-tuscan:latest
+FROM tuscan_base_image:latest
 MAINTAINER Kareem Khazem <khazem@google.com>
 
 COPY main.py /build/main.py

--- a/toolchains/install_bootstrap/android/setup.py
+++ b/toolchains/install_bootstrap/android/setup.py
@@ -29,9 +29,6 @@ import subprocess
 def toolchain_specific_setup(args):
     log("info", "Running android-specific setup")
 
-    cmd = "pacman -S --noconfirm wget sudo"
-    run_cmd(cmd, as_root=True)
-
     # wget and curl output unsuitable progress bars even when not
     # connected to a TTY. Turn them off.
     with open("/etc/wgetrc", "a") as f:

--- a/toolchains/install_bootstrap/musl/Dockerfile
+++ b/toolchains/install_bootstrap/musl/Dockerfile
@@ -19,7 +19,7 @@
 # USAGE:
 #   docker run container_name
 
-FROM karkhaz/arch-tuscan:latest
+FROM tuscan_base_image:latest
 MAINTAINER Kareem Khazem <khazem@google.com>
 
 COPY main.py /build/main.py

--- a/toolchains/install_bootstrap/musl/setup.sh
+++ b/toolchains/install_bootstrap/musl/setup.sh
@@ -29,9 +29,6 @@ die() {
   exit 1
 }
 
-pacman-key --refresh-keys
-pacman -Syy --noconfirm python binutils gcc bison cmake ninja make libunistring patch
-
 mkdir -p ${SRCDIR}/binutils
 curl -s -S http://ftp.gnu.org/gnu/binutils/binutils-2.26.tar.bz2 \
   | tar xj -C ${SRCDIR}/binutils --strip-components=1

--- a/toolchains/install_bootstrap/vanilla/Dockerfile
+++ b/toolchains/install_bootstrap/vanilla/Dockerfile
@@ -19,7 +19,7 @@
 # USAGE:
 #   docker run container_name
 
-FROM karkhaz/arch-tuscan:latest
+FROM tuscan_base_image:latest
 MAINTAINER Kareem Khazem <khazem@google.com>
 
 COPY main.py /build/main.py


### PR DESCRIPTION
The base container that all stages are based on, the local mirror of
binaries, and the store of sources are all created at the same time and
have the same version numbers.

This commit introduces a new stage: create_base_image. This stage is
responsible for downloading sources and binaries, and synchronising the
local package repository to these downloaded packages. Most stages are
now based on create_base_image; when create_base_image exits, it commits
its image so that other containers can use its repository.

create_base_image runs _two_ scripts: main.sh followed by main.py.
main.sh sets up the basic aspects of the Arch container, including
installing python and build tools and initialising pacman. main.py then
proceeds to download source and binary packages.

The install_bootstrap_packages stage now installs bootstrap packages
from the local repository downloaded by create_base_image, rather than
downloading them from a remote mirror.

tuscan_build.py skips the creation of create_base_image if that image
already exists. Since several hundred gigabytes of sources and binaries
must be downloaded atomically whenever a new base image is created,
tuscan_build will use an existing base image if one already exists. This
change introduces a new dependency on the docker-py wrapper for docker.

Most other changes introduced in this commit are re-basing later stages
onto create_base_image.
