### PR TITLE
HTML display of native tool invocations

### DIFF
--- a/tuscan/build.jinja.html
+++ b/tuscan/build.jinja.html
@@ -33,6 +33,18 @@
     <p>The build took {{ data["time"]}} and was
     {% if data["return_code"] is equalto 0 %}SUCCESSFUL.
     {% else %}NOT successful.{% endif %}
+    {% if data["native_tools"] %}
+    <p>This build attempted to bypass our toolchain by invoking native
+    tools; we intercepted these invocations and sent them to our
+    toolchain. The frequency of each native tool invocation is given
+    here:</p>
+    <table>
+      <tr><th>tool</th><th>frequency</th></tr>
+      {% for tool, freq in data["native_tools"].items() %}
+      <tr><td><code>{{ tool }}</code></td><td>{{ freq }}</td></tr>
+      {% endfor %}
+    </table>
+    {% endif %}
     </p>
     {% if data["blocked_by"] %}
     <p>


### PR DESCRIPTION
HTML reports of individual builds now display how many native tools were
invoked.

HTML summary pages now include the number of builds that invoked native
tools---both those that passed, and those that failed.
