### PR TITLE
Toolchains are created once and saved locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tuscan.ninja
 mirror
 sources
 output
+
+sysroots

--- a/package_build_wrapper.py
+++ b/package_build_wrapper.py
@@ -58,6 +58,7 @@ def run_container(args):
                " --volumes-from {toolchain_volume}"
                " -v {cwd}/mirror:/mirror:ro"
                " -v {cwd}/sources:/sources:ro"
+               " -v {cwd}/sysroots/{toolchain}:/toolchain_root:ro"
                " make_package"
 
                # Arguments to the make_package stage inside container:

--- a/stages/create_base_image/deps.yaml
+++ b/stages/create_base_image/deps.yaml
@@ -10,7 +10,7 @@ run:
     data_containers:
       - tuscan_data
     local_mounts:
-      - mirror
-      - sources
+      mirror: mirror
+      sources: sources
   rm_container: false
   post_exit: docker commit create_base_image tuscan_base_image

--- a/stages/install_bootstrap/deps.yaml
+++ b/stages/install_bootstrap/deps.yaml
@@ -13,10 +13,10 @@ run:
       - get_base_package_names
     data_containers:
       - tuscan_data
-      - toolchain_${TOOLCHAIN}_repo
     local_mounts:
-      - mirror
-      - bear
+      mirror: mirror
+      bear: bear
+      sysroots/${TOOLCHAIN}: toolchain_root
 
   # make_package containers are based on the image of this stage,
   # therefore don't delete the container when finished and do a docker

--- a/stages/install_bootstrap/main.py
+++ b/stages/install_bootstrap/main.py
@@ -96,9 +96,6 @@ def main():
         if cp.returncode:
             exit(1)
 
-    os.mkdir("/toolchain_root")
-    shutil.chown("/toolchain_root", "tuscan")
-
     # Replace native tools with thin wrappers
     with open("/build/tool_redirect_rules.yaml") as f:
         transforms = yaml.load(f)
@@ -143,7 +140,21 @@ def main():
             shutil.move(os.path.join(tmp_dir, wrapper),
                         os.path.join("/usr/bin", wrapper))
 
-    setup.toolchain_specific_setup(args)
+    if not os.path.isdir("/toolchain_root"):
+        log("error", "/toolchain_root is not mounted")
+        exit(1)
+
+    if os.listdir("/toolchain_root"):
+        log("info", ("Skipping toolchain-specific setup as "
+                     "/toolchain_root contains files. Listing:"),
+                     output=list(os.listdir("/toolchain_root")))
+    else:
+        log("info", ("/toolchain_root is empty, performing "
+                     "toolchain-specific setup"),
+                     output=list(os.listdir("/toolchain_root")))
+        setup.toolchain_specific_setup(args)
+
+    recursive_chown("/toolchain_root")
 
     exit(0)
 

--- a/toolchains/install_bootstrap/musl/setup.sh
+++ b/toolchains/install_bootstrap/musl/setup.sh
@@ -24,6 +24,11 @@ SRCDIR=/srcdir
 BUILDDIR=/musl_build
 PKGDIR=/toolchain_root
 
+if [ -d "$PKGDIR/clang+llvm-x86_64-archlinux/bin" ]; then
+  # We've already downloaded and built a toolchain
+  exit 0
+fi
+
 die() {
   echo "die: $*" 1>&2
   exit 1

--- a/tuscan/schemata.py
+++ b/tuscan/schemata.py
@@ -50,8 +50,12 @@ stage_deps_schema = voluptuous.Schema({
             voluptuous.Optional("stages"): [_nonempty_string],
             # Data containers that are used during the run of this stage
             voluptuous.Optional("data_containers"): [_nonempty_string],
-            # Directories that will be mounted in this stage's # container
-            voluptuous.Optional("local_mounts"): [_nonempty_string],
+            # Directories that will be mounted in this stage's
+            # container. This dictionary mounts the local directory to
+            # the directory it will be mounted under in the container.
+            voluptuous.Optional("local_mounts"): {
+                _nonempty_string: _nonempty_string
+            },
         }),
         # Instead of doing 'docker run', run a custom command
         voluptuous.Optional("command_override"): _nonempty_string,

--- a/tuscan/utilities.py
+++ b/tuscan/utilities.py
@@ -240,6 +240,8 @@ def get_argparser():
 
     parser.add_argument("--bear-directory")
 
+    parser.add_argument("--toolchain_root-directory")
+
     parser.add_argument("--stage-name",
                         dest="stage_name", action="store")
 


### PR DESCRIPTION
Toolchains are now downloaded and built into a locally-mounted
directory under the directory `sysroots`, rather than a data container.
If a particular toolchain already exists in `sysroots`, then it will not
be re-downloaded on subsequent invocations of `tuscan build` for that
toolchain.

This is to facilitate reproducibility of results. Before this commit,
there was no provision to load a pre-created toolchain into tuscan; each
toolchain would be downloaded from the upstream every time tuscan was
run. This commit will allow us to distribute pre-created toolchains to
others; tuscan will then use those toolchains rather than downloading
the latest version.
