### PR TITLE
HTML display of process tree

### DIFF
--- a/tuscan/build.jinja.html
+++ b/tuscan/build.jinja.html
@@ -32,7 +32,11 @@
         toolchain</h1>
     <p>The build took {{ data["time"]}} and was
     {% if data["return_code"] is equalto 0 %}SUCCESSFUL.
-    {% else %}NOT successful.{% endif %}
+    {% else %}NOT successful.{% endif %}</p>
+    <p>
+      The process tree of the build process is <a
+      href="{{ data['tree_path']}}">here</a>.
+    </p>
     {% if data["native_tools"] %}
     <p>This build attempted to bypass our toolchain by invoking native
     tools; we intercepted these invocations and sent them to our
@@ -45,7 +49,6 @@
       {% endfor %}
     </table>
     {% endif %}
-    </p>
     {% if data["blocked_by"] %}
     <p>
     We did not attempt to build this package because some of its

--- a/tuscan/build_tree.html.jinja
+++ b/tuscan/build_tree.html.jinja
@@ -1,0 +1,76 @@
+<html>
+  <head>
+  <meta charset="UTF-8">
+  <title>Build tree {{ toolchain }}/{{ build_name }}</title>
+  <link href='https://fonts.googleapis.com/css?family=Roboto:400,900'
+        rel='stylesheet' type='text/css'>
+  <link
+  href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700'
+        rel='stylesheet' type='text/css'>
+  <link href="../style.css" type="text/css" rel="stylesheet">
+  <style>
+  .good-return {
+    font-weight: bold;
+    color: blue;
+  }
+  .bad-return {
+    font-weight: bold;
+    color: red;
+  }
+  .no-return {
+    font-weight: bold;
+    color: purple;
+  }
+  li {
+    list-style: none;
+  }
+  ul{
+    padding-left: 1em;
+  }
+  .level-0{
+
+  }
+  .level-2{
+    background-color: #eee;
+  }
+  .level-4{
+    background-color: #ddd;
+  }
+  .level-6{
+    background-color: #ccc;
+  }
+  .level-8{
+    background-color: #bbb;
+  }
+  .level-10{
+    background-color: #aaa;
+  }
+  .level-12{
+    background-color: #999;
+  }
+  .level-14{
+    background-color: #999;
+    border-left: 1px dotted #222;
+  }
+  .level-16{
+    background-color: #999;
+    border-left: 1px dotted #222;
+  }
+  .level-18{
+    background-color: #999;
+    border-left: 1px dotted #222;
+  }
+  .level-20{
+    background-color: #999;
+    border-left: 1px dotted #222;
+  }
+  </style>
+  </head>
+  <body>
+    <h1>Build tree for &quot;<a
+    href="{{ build_name }}.html">{{ build_name }}</a>&quot;
+    on toolchain &quot;{{ toolchain }}&quot;
+    </h1>
+    {{ tree }}
+  <body>
+<html>


### PR DESCRIPTION
A HTML page of a build's process tree is now generated, and linked to
from the main page for each build.
